### PR TITLE
Changing to alpha versions for nugets

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ var DOCS_URL = "https://dl-ssl.google.com/android/repository/google_play_service
 var M2_REPOSITORY = "https://dl-ssl.google.com/android/repository/google_m2repository_r27.zip";
 
 var PLAY_COMPONENT_VERSION = "30.0.1.0";
-var PLAY_NUGET_VERSION = "30.0.1-beta1";
+var PLAY_NUGET_VERSION = "30.0.1-alpha1";
 var PLAY_AAR_VERSION = "9.0.1";
 
 var WEAR_COMPONENT_VERSION = "1.4.0.0";


### PR DESCRIPTION
Not quite ready to call this beta, let's keep it as -alpha* for now.
