### PR TITLE
V9.0.1 Mac Build Fixes

### DIFF
--- a/ads-lite/nuget/Xamarin.GooglePlayServices.Ads.Lite.nuspec
+++ b/ads-lite/nuget/Xamarin.GooglePlayServices.Ads.Lite.nuspec
@@ -22,6 +22,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Ads.Lite.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Ads.Lite.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/ads/nuget/Xamarin.GooglePlayServices.Ads.nuspec
+++ b/ads/nuget/Xamarin.GooglePlayServices.Ads.nuspec
@@ -22,6 +22,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Ads.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Ads.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/all/nuget/Xamarin.GooglePlayServices.nuspec
+++ b/all/nuget/Xamarin.GooglePlayServices.nuspec
@@ -44,6 +44,6 @@
   </metadata>  
   <files>
     <file src="readme.txt" target="" />
-    <!-- <file src="output/GooglePlayServicesLib.dll" target="lib\MonoAndroid41" /> -->
+    <!-- <file src="output/GooglePlayServicesLib.dll" target="lib/MonoAndroid41" /> -->
   </files>
 </package>

--- a/analytics-impl/nuget/Xamarin.GooglePlayServices.Analytics.Impl.nuspec
+++ b/analytics-impl/nuget/Xamarin.GooglePlayServices.Analytics.Impl.nuspec
@@ -22,6 +22,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Analytics.Impl.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Analytics.Impl.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/analytics/nuget/Xamarin.GooglePlayServices.Analytics.nuspec
+++ b/analytics/nuget/Xamarin.GooglePlayServices.Analytics.nuspec
@@ -22,6 +22,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Analytics.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Analytics.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/appindexing/nuget/Xamarin.GooglePlayServices.AppIndexing.nuspec
+++ b/appindexing/nuget/Xamarin.GooglePlayServices.AppIndexing.nuspec
@@ -23,6 +23,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.AppIndexing.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.AppIndexing.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/appinvite/nuget/Xamarin.GooglePlayServices.AppInvite.nuspec
+++ b/appinvite/nuget/Xamarin.GooglePlayServices.AppInvite.nuspec
@@ -23,6 +23,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.AppInvite.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.AppInvite.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/appstate/nuget/Xamarin.GooglePlayServices.AppState.nuspec
+++ b/appstate/nuget/Xamarin.GooglePlayServices.AppState.nuspec
@@ -20,6 +20,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.AppState.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.AppState.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/auth-base/nuget/Xamarin.GooglePlayServices.Auth.Base.nuspec
+++ b/auth-base/nuget/Xamarin.GooglePlayServices.Auth.Base.nuspec
@@ -20,6 +20,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Auth.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Auth.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/auth/nuget/Xamarin.GooglePlayServices.Auth.nuspec
+++ b/auth/nuget/Xamarin.GooglePlayServices.Auth.nuspec
@@ -20,6 +20,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Auth.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Auth.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/base/nuget/Xamarin.GooglePlayServices.Base.nuspec
+++ b/base/nuget/Xamarin.GooglePlayServices.Base.nuspec
@@ -44,6 +44,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Base.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Base.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/basement/nuget/Xamarin.GooglePlayServices.Basement.nuspec
+++ b/basement/nuget/Xamarin.GooglePlayServices.Basement.nuspec
@@ -47,6 +47,6 @@
   <files>
     <file src="basement/buildtasks/bin/Release/Xamarin.GooglePlayServices.Basement.targets" target="build" />
 
-    <file src="output/Xamarin.GooglePlayServices.Basement.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Basement.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ fi
 # Download NuGet if it does not exist.
 if [ ! -f "$NUGET_EXE" ]; then
     echo "Downloading NuGet..."
-    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe
     if [ $? -ne 0 ]; then
         echo "An error occured while downloading nuget.exe."
         exit 1

--- a/cast/nuget/Xamarin.GooglePlayServices.Cast.nuspec
+++ b/cast/nuget/Xamarin.GooglePlayServices.Cast.nuspec
@@ -26,6 +26,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Cast.dll" target="lib\MonoAndroid42" />
+    <file src="output/Xamarin.GooglePlayServices.Cast.dll" target="lib/MonoAndroid42" />
   </files>
 </package>

--- a/drive/nuget/Xamarin.GooglePlayServices.Drive.nuspec
+++ b/drive/nuget/Xamarin.GooglePlayServices.Drive.nuspec
@@ -23,6 +23,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Drive.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Drive.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-ads/nuget/Xamarin.Firebase.Ads.nuspec
+++ b/firebase-ads/nuget/Xamarin.Firebase.Ads.nuspec
@@ -22,6 +22,6 @@
   </metadata>
   <files>
     <!-- No files, just a wrapper around other packages -->
-    <!-- <file src="output/Xamarin.Firebase.Ads.dll" target="lib\MonoAndroid41" /> -->
+    <!-- <file src="output/Xamarin.Firebase.Ads.dll" target="lib/MonoAndroid41" /> -->
   </files>
 </package>

--- a/firebase-analytics-impl/nuget/Xamarin.Firebase.Analytics.Impl.nuspec
+++ b/firebase-analytics-impl/nuget/Xamarin.Firebase.Analytics.Impl.nuspec
@@ -21,6 +21,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Analytics.Impl.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Analytics.Impl.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-analytics/nuget/Xamarin.Firebase.Analytics.nuspec
+++ b/firebase-analytics/nuget/Xamarin.Firebase.Analytics.nuspec
@@ -21,6 +21,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Analytics.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Analytics.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-auth-common/nuget/Xamarin.Firebase.Auth.Common.nuspec
+++ b/firebase-auth-common/nuget/Xamarin.Firebase.Auth.Common.nuspec
@@ -23,6 +23,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Auth.Common.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Auth.Common.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-auth-module/nuget/Xamarin.Firebase.Auth.Module.nuspec
+++ b/firebase-auth-module/nuget/Xamarin.Firebase.Auth.Module.nuspec
@@ -21,6 +21,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Auth.Module.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Auth.Module.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-auth/nuget/Xamarin.Firebase.Auth.nuspec
+++ b/firebase-auth/nuget/Xamarin.Firebase.Auth.nuspec
@@ -24,6 +24,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Auth.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Auth.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-common/nuget/Xamarin.Firebase.Common.nuspec
+++ b/firebase-common/nuget/Xamarin.Firebase.Common.nuspec
@@ -21,6 +21,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Common.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Common.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-config/nuget/Xamarin.Firebase.Config.nuspec
+++ b/firebase-config/nuget/Xamarin.Firebase.Config.nuspec
@@ -24,6 +24,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Config.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Config.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-core/nuget/Xamarin.Firebase.Core.nuspec
+++ b/firebase-core/nuget/Xamarin.Firebase.Core.nuspec
@@ -21,6 +21,6 @@
   </metadata>
   <files>
     <!-- No files, just a wrapper around other packages -->
-    <!-- <file src="output/Xamarin.Firebase.Core.dll" target="lib\MonoAndroid41" /> -->
+    <!-- <file src="output/Xamarin.Firebase.Core.dll" target="lib/MonoAndroid41" /> -->
   </files>
 </package>

--- a/firebase-crash/nuget/Xamarin.Firebase.Crash.nuspec
+++ b/firebase-crash/nuget/Xamarin.Firebase.Crash.nuspec
@@ -24,6 +24,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Crash.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Crash.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-database-connection/nuget/Xamarin.Firebase.Database.Connection.nuspec
+++ b/firebase-database-connection/nuget/Xamarin.Firebase.Database.Connection.nuspec
@@ -22,6 +22,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Database.Connection.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Database.Connection.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-database/nuget/Xamarin.Firebase.Database.nuspec
+++ b/firebase-database/nuget/Xamarin.Firebase.Database.nuspec
@@ -24,6 +24,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Database.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Database.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-iid/nuget/Xamarin.Firebase.Iid.nuspec
+++ b/firebase-iid/nuget/Xamarin.Firebase.Iid.nuspec
@@ -21,6 +21,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Iid.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Iid.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-messaging/nuget/Xamarin.Firebase.Messaging.nuspec
+++ b/firebase-messaging/nuget/Xamarin.Firebase.Messaging.nuspec
@@ -22,6 +22,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Messaging.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Messaging.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-storage-common/nuget/Xamarin.Firebase.Storage.Common.nuspec
+++ b/firebase-storage-common/nuget/Xamarin.Firebase.Storage.Common.nuspec
@@ -21,6 +21,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Storage.Common.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Storage.Common.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/firebase-storage/nuget/Xamarin.Firebase.Storage.nuspec
+++ b/firebase-storage/nuget/Xamarin.Firebase.Storage.nuspec
@@ -24,6 +24,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.Firebase.Storage.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.Firebase.Storage.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/fitness/nuget/Xamarin.GooglePlayServices.Fitness.nuspec
+++ b/fitness/nuget/Xamarin.GooglePlayServices.Fitness.nuspec
@@ -26,6 +26,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Fitness.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Fitness.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/games/nuget/Xamarin.GooglePlayServices.Games.nuspec
+++ b/games/nuget/Xamarin.GooglePlayServices.Games.nuspec
@@ -24,6 +24,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Games.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Games.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/gcm/nuget/Xamarin.GooglePlayServices.Gcm.nuspec
+++ b/gcm/nuget/Xamarin.GooglePlayServices.Gcm.nuspec
@@ -26,6 +26,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Gcm.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Gcm.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/identity/nuget/Xamarin.GooglePlayServices.Identity.nuspec
+++ b/identity/nuget/Xamarin.GooglePlayServices.Identity.nuspec
@@ -21,6 +21,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Identity.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Identity.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/iid/nuget/Xamarin.GooglePlayServices.Iid.nuspec
+++ b/iid/nuget/Xamarin.GooglePlayServices.Iid.nuspec
@@ -20,6 +20,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Iid.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Iid.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/location/nuget/Xamarin.GooglePlayServices.Location.nuspec
+++ b/location/nuget/Xamarin.GooglePlayServices.Location.nuspec
@@ -24,6 +24,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Location.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Location.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/maps/nuget/Xamarin.GooglePlayServices.Maps.nuspec
+++ b/maps/nuget/Xamarin.GooglePlayServices.Maps.nuspec
@@ -24,6 +24,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Maps.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Maps.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/measurement/nuget/Xamarin.GooglePlayServices.Measurement.nuspec
+++ b/measurement/nuget/Xamarin.GooglePlayServices.Measurement.nuspec
@@ -21,6 +21,6 @@
     </dependencies>    
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Measurement.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Measurement.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/nearby/nuget/Xamarin.GooglePlayServices.Nearby.nuspec
+++ b/nearby/nuget/Xamarin.GooglePlayServices.Nearby.nuspec
@@ -23,6 +23,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Nearby.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Nearby.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/panorama/nuget/Xamarin.GooglePlayServices.Panorama.nuspec
+++ b/panorama/nuget/Xamarin.GooglePlayServices.Panorama.nuspec
@@ -23,6 +23,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Panorama.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Panorama.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/plus/nuget/Xamarin.GooglePlayServices.Plus.nuspec
+++ b/plus/nuget/Xamarin.GooglePlayServices.Plus.nuspec
@@ -22,6 +22,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Plus.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Plus.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/safetynet/nuget/Xamarin.GooglePlayServices.SafetyNet.nuspec
+++ b/safetynet/nuget/Xamarin.GooglePlayServices.SafetyNet.nuspec
@@ -23,6 +23,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.SafetyNet.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.SafetyNet.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/support-wearable/nuget/Xamarin.Android.Wear.nuspec
+++ b/support-wearable/nuget/Xamarin.Android.Wear.nuspec
@@ -29,6 +29,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.Android.Wearable.dll" target="lib\MonoAndroid50" />
+    <file src="output/Xamarin.Android.Wearable.dll" target="lib/MonoAndroid50" />
   </files>
 </package>

--- a/tagmanager-api/nuget/Xamarin.GooglePlayServices.TagManager.Api.nuspec
+++ b/tagmanager-api/nuget/Xamarin.GooglePlayServices.TagManager.Api.nuspec
@@ -20,6 +20,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.TagManager.Api.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.TagManager.Api.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/tagmanager/nuget/Xamarin.GooglePlayServices.TagManager.nuspec
+++ b/tagmanager/nuget/Xamarin.GooglePlayServices.TagManager.nuspec
@@ -20,6 +20,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.TagManager.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.TagManager.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/tasks/nuget/Xamarin.GooglePlayServices.Tasks.nuspec
+++ b/tasks/nuget/Xamarin.GooglePlayServices.Tasks.nuspec
@@ -21,6 +21,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Tasks.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Tasks.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/vision/nuget/Xamarin.GooglePlayServices.Vision.nuspec
+++ b/vision/nuget/Xamarin.GooglePlayServices.Vision.nuspec
@@ -27,6 +27,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Vision.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Vision.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/wallet/nuget/Xamarin.GooglePlayServices.Wallet.nuspec
+++ b/wallet/nuget/Xamarin.GooglePlayServices.Wallet.nuspec
@@ -26,6 +26,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Wallet.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Wallet.dll" target="lib/MonoAndroid41" />
   </files>
 </package>

--- a/wearable/nuget/Xamarin.GooglePlayServices.Wearable.nuspec
+++ b/wearable/nuget/Xamarin.GooglePlayServices.Wearable.nuspec
@@ -25,6 +25,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="output/Xamarin.GooglePlayServices.Wearable.dll" target="lib\MonoAndroid41" />
+    <file src="output/Xamarin.GooglePlayServices.Wearable.dll" target="lib/MonoAndroid41" />
   </files>
 </package>


### PR DESCRIPTION
Changes slash used in nuspec files' target attribute to be more friendly on OSX for packaging.

Also pins nuget to v3.4.4 for builds