### PR TITLE
[maps]Fix wrong Polygon.SetHoles parameter type

### DIFF
--- a/maps/source/Additions/Additions.cs
+++ b/maps/source/Additions/Additions.cs
@@ -9,11 +9,11 @@ namespace Android.Gms.Maps.Model
         static IntPtr id_setHoles_Ljava_util_List_;
         // Metadata.xml XPath method reference: path="/api/package[@name='com.google.android.gms.maps.model']/class[@name='Polygon']/method[@name='setHoles' and count(parameter)=1 and parameter[1][@type='java.util.List&lt;&gt;']]"
         [Register ("setHoles", "(Ljava/util/List;)V", "")]
-        public unsafe void SetHoles (global::System.Collections.Generic.IList<LatLng> holes)
+        public unsafe void SetHoles (global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<LatLng>> holes)
         {
             if (id_setHoles_Ljava_util_List_ == IntPtr.Zero)
                 id_setHoles_Ljava_util_List_ = JNIEnv.GetMethodID (class_ref, "setHoles", "(Ljava/util/List;)V");
-            IntPtr native_holes = global::Android.Runtime.JavaList<LatLng>.ToLocalJniHandle (holes);
+            IntPtr native_holes = global::Android.Runtime.JavaList<global::System.Collections.Generic.IList<LatLng>>.ToLocalJniHandle (holes);
             try {
                 JValue* __args = stackalloc JValue [1];
                 __args [0] = new JValue (native_holes);


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):

* 10.2.4

### Does this change any of the generated binding API's?

Yes.

Xamarin.GooglePlayServices.Maps

Before: ``Polygon.SetHoles(IList<LatLng> holes)``
After: ``Polygon.SetHoles(IList<IList<LatLng>> holes)``

### Describe your contribution

I think ``Polygon.SetHoles(IList<LatLng> holes)`` is wrong parameter type.
Because the original Google Maps Android API has ``List<List<LatLng>>`` parameter type.

[``Polygon::setHoles (List<? extends List<LatLng>> holes)``](http://bit.ly/2rlfJPO)

I fix this and works fine in my test apps.