### PR TITLE
Fix ProtoliteWellKnownTypes nuget package id

### DIFF
--- a/protolite-well-known-types/nuget/Xamarin.Firebase.ProtoliteWellKnownTypes.template.nuspec
+++ b/protolite-well-known-types/nuget/Xamarin.Firebase.ProtoliteWellKnownTypes.template.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>Xamarin.GooglePlayServices.ProtoliteWellKnownTypes</id>
+    <id>Xamarin.Firebase.ProtoliteWellKnownTypes</id>
     <title>Xamarin Google Play Services - ProtoliteWellKnownTypes</title>
     <version>$version$</version>
     <authors>Xamarin Inc.</authors>

--- a/protolite-well-known-types/source/Properties/AssemblyInfo.cs
+++ b/protolite-well-known-types/source/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using Android.App;
 // Information about this assembly is defined by the following attributes.
 // Change them to the values specific to your project.
 
-[assembly: AssemblyTitle ("Xamarin.GooglePlayServices.Protolite.Well.Known.Types")]
+[assembly: AssemblyTitle ("Xamarin.Firebase.Protolite.Well.Known.Types")]
 [assembly: AssemblyDescription ("")]
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("Microsoft Corporation")]


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):

15.0.1

### Does this change any of the generated binding API's?

No

### Describe your contribution

Firebase.Firestore requires `Xamarin.Firebase.ProtoliteWellKnownTypes`, but `Xamarin.Firebase.ProtoliteWellKnownTypes` 's nuget id is `Xamarin.GooglePlayServices.ProtoliteWellKnownTypes`.
So I renamed.
