### PR TITLE
Add Xamarin.Google.Guava dep to Firebase.Firestore nuspec

### DIFF
--- a/firebase-firestore/nuget/Xamarin.Firebase.Firestore.template.nuspec
+++ b/firebase-firestore/nuget/Xamarin.Firebase.Firestore.template.nuspec
@@ -21,6 +21,7 @@
         <dependency id="Xamarin.Firebase.Common" version="[$version$]" />
         <dependency id="Xamarin.GooglePlayServices.Basement" version="[$version$]" />
         <dependency id="Xamarin.GooglePlayServices.Tasks" version="[$version$]" />
+        <dependency id="Xamarin.Google.Guava" version="23.2.0" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):

11.4.2

### Does this change any of the generated binding API's?

No

### Describe your contribution

Add dependency `Xamarin.Google.Guava` to Firebase.Firestore .
In csproj, firestore depends it, but missing in nuspec.
https://github.com/xamarin/GooglePlayServicesComponents/blob/master/firebase-firestore/source/Firebase-Firestore.csproj#L83

If we don't add Xamarin.Google.Guava to project, application will crash.