### PR TITLE
Fix for NewTrace method in FireBase Performance Monitoring

### DIFF
--- a/source/com.google.firebase/firebase-perf/Transforms/Metadata.xml
+++ b/source/com.google.firebase/firebase-perf/Transforms/Metadata.xml
@@ -27,6 +27,5 @@
 	<attr path="/api/*/*/method[@name='writeToParcel']/parameter[@name='p1']" name="managedName">flags</attr>
     
     <attr path="/api/package/*[@extends='com.google.android.gms.internal.zzekz']" name="extends">java.lang.Object</attr>
-    <attr path="/api/package/*[@extends='com.google.android.gms.internal.firebase-perf.zze']" name="extends">java.lang.Object</attr>
-    
+    <attr path="/api/package/*[@extends='com.google.firebase.perf.internal.zzb']" name="extends">java.lang.Object</attr>
 </metadata>


### PR DESCRIPTION
Add the proper Reference for the Trace class to be visible for the newtrace method

### Google Play Services Version (eg: 8.4.0):
   Version: 9.0
### Does this change any of the generated binding API's?
       FirebasePerformance.Instance.NewTrace in firebase-perf

### Describe your contribution
Right now the new AAR downloaded for firebase performance is the version 16.2.0 in the config.json file.
This native file has a new implementation for the method newtrace as follow :
`com.google.firebase.perf.internal.zzb` instead of `com.google.android.gms.internal.firebase-perf.zze` that was available in the previous version.