### PR TITLE
[msbuild] fix for $(AndroidUseAapt2)

### DIFF
--- a/source/com.google.android.gms/play-services-basement/merge.targets
+++ b/source/com.google.android.gms/play-services-basement/merge.targets
@@ -48,10 +48,6 @@
     <ConvertToAbsolutePath Paths="$(ProcessGoogleServicesJsonResDirPath)">
       <Output TaskParameter="AbsolutePaths" PropertyName="ProcessGoogleServicesJsonResDirPathAbs"/>
     </ConvertToAbsolutePath>
-
-    <ItemGroup>
-        <LibraryResourceDirectories Condition="Exists ('$(ProcessGoogleServicesJsonResDirPathAbs)')" Include="$(ProcessGoogleServicesJsonResDirPathAbs)" />
-    </ItemGroup>
   </Target>
 
 
@@ -74,6 +70,9 @@
     </ProcessGoogleServicesJson>
 
     <ItemGroup>
+        <LibraryResourceDirectories Condition="Exists ('$(ProcessGoogleServicesJsonResDirPathAbs)')" Include="$(ProcessGoogleServicesJsonResDirPathAbs)">
+            <StampFile>$(IntermediateOutputPath)googsvcsjson.stamp</StampFile>
+        </LibraryResourceDirectories>
         <FileWrites Condition="Exists ('$(ProcessGoogleServicesJsonResStringsPath)')" Include="$(ProcessGoogleServicesJsonResStringsPath)" />
         <FileWrites Condition="Exists ('$(ProcessGoogleServicesJsonResXmlPath)')" Include="$(ProcessGoogleServicesJsonResXmlPath)" />
     </ItemGroup>


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):

Latest

### Does this change any of the generated binding API's?

Nope

### Describe your contribution

If used in a Xamarin.Android project with aapt2,
`@(GoogleServicesJson)` items cause targets to run on every build:

    Building target "_ConvertLibraryResourcesCases" completely.
    Input file "obj\Debug.stamp" does not exist.

So one problem, is Xamarin.Android has some logic to decide the path
of the `.stamp` file on directories that are normally in
`obj\Debug\lp\1\`:

https://github.com/xamarin/xamarin-android/blob/b6f7f0e40ac9e500acd59ba61f045f7dde5dcc99/src/Xamarin.Android.Build.Tasks/Tasks/CollectNonEmptyDirectories.cs#L30

We need to make fixes in Xamarin.Android, but a workaround is to set
the `%(StampFile)` metadata on `@(LibraryResourceDirectories)`. This
will make our targets rerun aapt2 only when a `@(GoogleServicesJson)`
file changes.