### PR TITLE
Fix the incompatibility issue between Analytics and Messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Execute the following commands to install the necessary tools:
 ```
 dotnet tool install --global Cake.Tool
 dotnet tool install -g Xamarin.AndroidBinderator.Tool
-dotnet tool install -g "xamarin.androidx.migration.tool
+dotnet tool install -g xamarin.androidx.migration.tool
 ```
-Then you can use the the scripts to generate the buidings
+Then you can use the scripts to generate buidings
 
 **Mac**:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ The following targets can be specified:
 
 You may want to consider passing `--verbosity diagnostic` (or `-Verbosity diagnostic` on Windows) to the bootstrapper to enable more verbose output, including downloading progress.
 
+Execute the following commands to install the necessary tools:
+
+```
+dotnet tool install --global Cake.Tool
+dotnet tool install -g Xamarin.AndroidBinderator.Tool
+dotnet tool install -g "xamarin.androidx.migration.tool
+```
+Then you can use the the scripts to generate the buidings
+
 **Mac**:
 
 ```

--- a/config.json
+++ b/config.json
@@ -254,25 +254,49 @@
 		},
 		{
 			"groupId" : "com.google.android.gms",
+			"artifactId" : "play-services-measurement",
+			"version" : "16.5.0",
+			"nugetVersion" : "71.1650.0",
+			"nugetId" : "Xamarin.GooglePlayServices.Measurement",
+			"dependencyOnly" : false
+		},
+		{
+			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-measurement-base",
-			"version" : "16.3.0",
-			"nugetVersion" : "71.1630.0",
+			"version" : "16.5.0",
+			"nugetVersion" : "71.1650.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Measurement.Base",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.android.gms",
+			"artifactId" : "play-services-measurement-impl",
+			"version" : "16.5.0",
+			"nugetVersion" : "71.1650.0",
+			"nugetId" : "Xamarin.GooglePlayServices.Measurement.Impl",
+			"dependencyOnly" : false
+		},
+		{
+			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-measurement-api",
-			"version" : "16.3.0",
-			"nugetVersion" : "71.1630.0",
+			"version" : "16.5.0",
+			"nugetVersion" : "71.1650.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Measurement.Api",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.android.gms",
+			"artifactId" : "play-services-measurement-sdk",
+			"version" : "16.5.0",
+			"nugetVersion" : "71.1650.0",
+			"nugetId" : "Xamarin.GooglePlayServices.Measurement.Sdk",
+			"dependencyOnly" : false
+		},
+		{
+			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-measurement-sdk-api",
-			"version" : "16.3.0",
-			"nugetVersion" : "71.1630.0",
+			"version" : "16.5.0",
+			"nugetVersion" : "71.1650.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Measurement.Sdk.Api",
 			"dependencyOnly" : false
 		},
@@ -450,8 +474,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-analytics",
-			"version" : "16.3.0",
-			"nugetVersion" : "71.1630.0",
+			"version" : "16.5.0",
+			"nugetVersion" : "71.1650.0",
 			"nugetId" : "Xamarin.Firebase.Analytics",
 			"dependencyOnly" : false
 		},
@@ -461,7 +485,7 @@
 			"version" : "16.3.0",
 			"nugetVersion" : "71.1630.0",
 			"nugetId" : "Xamarin.Firebase.Analytics.Impl",
-			"dependencyOnly" : false
+			"dependencyOnly" : true
 		},
 		{
 			"groupId" : "com.google.firebase",
@@ -578,8 +602,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-iid",
-			"version" : "17.1.0",
-			"nugetVersion" : "71.1710.0",
+			"version" : "17.1.2",
+			"nugetVersion" : "71.1712.0",
 			"nugetId" : "Xamarin.Firebase.Iid",
 			"dependencyOnly" : false
 		},
@@ -613,13 +637,13 @@
 			"version" : "17.0.5",
 			"nugetVersion" : "71.1705.0",
 			"nugetId" : "Xamarin.Firebase.Measurement.Connector.Impl",
-			"dependencyOnly" : false
+			"dependencyOnly" : true
 		},
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-messaging",
-			"version" : "17.4.0",
-			"nugetVersion" : "71.1740.0",
+			"version" : "17.6.0",
+			"nugetVersion" : "71.1760.0",
 			"nugetId" : "Xamarin.Firebase.Messaging",
 			"dependencyOnly" : false
 		},

--- a/config.json
+++ b/config.json
@@ -23,16 +23,16 @@
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-ads",
-			"version" : "17.2.0",
-			"nugetVersion" : "71.1720.1",
+			"version" : "17.2.1",
+			"nugetVersion" : "71.1721.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Ads",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-ads-base",
-			"version" : "17.2.0",
-			"nugetVersion" : "71.1720.0",
+			"version" : "17.2.1",
+			"nugetVersion" : "71.1721.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Ads.Base",
 			"dependencyOnly" : false
 		},
@@ -47,8 +47,8 @@
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-ads-lite",
-			"version" : "17.2.0",
-			"nugetVersion" : "71.1720.1",
+			"version" : "17.2.1",
+			"nugetVersion" : "71.1721.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Ads.Lite",
 			"dependencyOnly" : false
 		},
@@ -199,8 +199,8 @@
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-gass",
-			"version" : "17.2.0",
-			"nugetVersion" : "71.1720.0",
+			"version" : "17.2.1",
+			"nugetVersion" : "71.1721.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Gass",
 			"dependencyOnly" : false
 		},
@@ -450,8 +450,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-abt",
-			"version" : "16.0.1",
-			"nugetVersion" : "71.1601.0",
+			"version" : "17.1.1",
+			"nugetVersion" : "71.1711.0",
 			"nugetId" : "Xamarin.Firebase.Abt",
 			"dependencyOnly" : false
 		},
@@ -522,8 +522,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-common",
-			"version" : "16.1.0",
-			"nugetVersion" : "71.1610.0",
+			"version" : "17.1.0",
+			"nugetVersion" : "71.1710.0",
 			"nugetId" : "Xamarin.Firebase.Common",
 			"dependencyOnly" : false
 		},


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):
V9.0


### Does this change any of the generated binding API's?
Yes

### Describe your contribution

* Fix the incompatibility Issue between Analytics and Messaging by upgrading the proper dependencies.
https://github.com/xamarin/GooglePlayServicesComponents/issues/280

* "Seal" the sub-dependencies with seams to do not evolve anymore according to maven last update. This will help the Android-Binderator to complete his Dependencies check
