### PR TITLE
Remove `XamarinBuildDownloadRestoreAssemblyAar`

### DIFF
--- a/template.targets
+++ b/template.targets
@@ -32,12 +32,5 @@
                 <Md5>$XbdMd5$</Md5>
             </XamarinBuildDownload>
         </ItemGroup>
-
-        <ItemGroup>
-            <XamarinBuildDownloadRestoreAssemblyAar Include="$(_XbdAarFileFullPath_)">
-                <LogicalName>__AndroidLibraryProjects__.zip</LogicalName>
-                <AssemblyName>$(_XbdAssemblyName_)</AssemblyName>
-            </XamarinBuildDownloadRestoreAssemblyAar>
-        </ItemGroup>
     </Target>
 </Project>


### PR DESCRIPTION
Since Xamarin.Build.Download 0.10.0, the `XamarinBuildDownloadRestoreAssemblyAar` item group is no longer necessary or used, however the existence of items in this group generate a build warning which is confusing many users.  

We kept both of these in this package in case old versions of XBD were used in a project, especially those which relied on an old Xamarin.Android that did not support the new `AndroidAarLibrary` item group which the new XBD `XamarinBuildDownloadAndroidAarLibrary` item leverages to avoid embedding the .aar inside the .dll at build time.

I think at this point it is safe to remove as we are many Xamarin.Android versions since the new support was added for including aar's from a file in the build, and we are a few GPS/FB releases that users could stick to which still allow the older Xamarin.Android and XBD to be used.

