### PR TITLE
Generate solution filters for working in Visual Studio.

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,6 +17,10 @@
 		{
 			"templateFile": "source/GooglePlayServicesPom.cshtml",
 			"outputFileRule" : "generated/{groupid}.{artifactid}/pom.xml"
+		},
+		{
+			"templateFile": "source/GooglePlayServicesSolutionFilter.cshtml",
+			"outputFileRule" : "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.slnf"
 		}
 	],
 	"artifacts" : [

--- a/source/GooglePlayServicesSolutionFilter.cshtml
+++ b/source/GooglePlayServicesSolutionFilter.cshtml
@@ -1,0 +1,16 @@
+@using System.Linq
+{
+  "solution": {
+    "path": "..\\GooglePlayServices.sln",
+    "projects": [
+@foreach (var dep in @Model.NuGetDependencies)
+{
+    if (dep.IsProjectReference)
+    {
+        <text>"@($"{dep.MavenArtifact.MavenGroupId}.{dep.MavenArtifact.MavenArtifactId}\\\\{dep.MavenArtifact.MavenGroupId}.{dep.MavenArtifact.MavenArtifactId}.csproj")",</text>
+    }
+}
+"@($"{Model.MavenGroupId}.{Model.Name}\\\\{Model.MavenGroupId}.{Model.Name}.csproj")"
+    ]
+  }
+}


### PR DESCRIPTION
Binderator generates a `GooglePlayServices.sln` file which can be used in Visual Studio, however it contains 110 projects, which does not make VS very happy. This adds a template to generate solution filter (.slnf) files next to each project file. This allows you to open only the current project plus its project references in Visual Studio.