### PR TITLE
GPS/FB July 2020 Updates

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,16 +27,16 @@
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-ads",
-			"version" : "19.1.0",
-			"nugetVersion" : "119.1.0",
+			"version" : "19.3.0",
+			"nugetVersion" : "119.3.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Ads",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-ads-base",
-			"version" : "19.1.0",
-			"nugetVersion" : "119.1.0",
+			"version" : "19.3.0",
+			"nugetVersion" : "119.3.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Ads.Base",
 			"dependencyOnly" : false
 		},
@@ -51,8 +51,8 @@
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-ads-lite",
-			"version" : "19.1.0",
-			"nugetVersion" : "119.1.0",
+			"version" : "19.3.0",
+			"nugetVersion" : "119.3.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Ads.Lite",
 			"dependencyOnly" : false
 		},
@@ -99,8 +99,8 @@
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-auth",
-			"version" : "18.0.0",
-			"nugetVersion" : "118.0.0",
+			"version" : "18.1.0",
+			"nugetVersion" : "118.1.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Auth",
 			"dependencyOnly" : false
 		},
@@ -147,16 +147,16 @@
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-cast",
-			"version" : "18.1.0",
-			"nugetVersion" : "118.1.0",
+			"version" : "19.0.0",
+			"nugetVersion" : "119.0.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Cast",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-cast-framework",
-			"version" : "18.1.0",
-			"nugetVersion" : "118.1.0",
+			"version" : "19.0.0",
+			"nugetVersion" : "119.0.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Cast.Framework",
 			"dependencyOnly" : false
 		},
@@ -219,8 +219,8 @@
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-gass",
-			"version" : "19.1.0",
-			"nugetVersion" : "119.1.0",
+			"version" : "19.3.0",
+			"nugetVersion" : "119.3.0",
 			"nugetId" : "Xamarin.GooglePlayServices.Gass",
 			"dependencyOnly" : false
 		},
@@ -275,48 +275,48 @@
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-measurement",
-			"version" : "17.4.1",
-			"nugetVersion" : "117.4.1",
+			"version" : "17.4.4",
+			"nugetVersion" : "117.4.4",
 			"nugetId" : "Xamarin.GooglePlayServices.Measurement",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-measurement-api",
-			"version" : "17.4.1",
-			"nugetVersion" : "117.4.1",
+			"version" : "17.4.4",
+			"nugetVersion" : "117.4.4",
 			"nugetId" : "Xamarin.GooglePlayServices.Measurement.Api",      
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-measurement-base",
-			"version" : "17.4.1",
-			"nugetVersion" : "117.4.1",
+			"version" : "17.4.4",
+			"nugetVersion" : "117.4.4",
 			"nugetId" : "Xamarin.GooglePlayServices.Measurement.Base",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-measurement-impl",
-			"version" : "17.4.1",
-			"nugetVersion" : "117.4.1",
+			"version" : "17.4.4",
+			"nugetVersion" : "117.4.4",
 			"nugetId" : "Xamarin.GooglePlayServices.Measurement.Impl",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-measurement-sdk",
-			"version" : "17.4.1",
-			"nugetVersion" : "117.4.1",
+			"version" : "17.4.4",
+			"nugetVersion" : "117.4.4",
 			"nugetId" : "Xamarin.GooglePlayServices.Measurement.Sdk",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.android.gms",
 			"artifactId" : "play-services-measurement-sdk-api",
-			"version" : "17.4.1",
-			"nugetVersion" : "117.4.1",
+			"version" : "17.4.4",
+			"nugetVersion" : "117.4.4",
 			"nugetId" : "Xamarin.GooglePlayServices.Measurement.Sdk.Api",
 			"dependencyOnly" : false
 		},
@@ -487,32 +487,32 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-abt",
-			"version" : "19.0.1",
-			"nugetVersion" : "119.0.1",
+			"version" : "19.1.0",
+			"nugetVersion" : "119.1.0",
 			"nugetId" : "Xamarin.Firebase.Abt",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-ads",
-			"version" : "19.1.0",
-			"nugetVersion" : "119.1.0",
+			"version" : "19.3.0",
+			"nugetVersion" : "119.3.0",
 			"nugetId" : "Xamarin.Firebase.Ads",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-ads-lite",
-			"version" : "19.1.0",
-			"nugetVersion" : "119.1.0",
+			"version" : "19.3.0",
+			"nugetVersion" : "119.3.0",
 			"nugetId" : "Xamarin.Firebase.Ads.Lite",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-analytics",
-			"version" : "17.4.1",
-			"nugetVersion" : "117.4.1",
+			"version" : "17.4.4",
+			"nugetVersion" : "117.4.4",
 			"nugetId" : "Xamarin.Firebase.Analytics",
 			"dependencyOnly" : false
 		},
@@ -539,8 +539,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-auth",
-			"version" : "19.3.1",
-			"nugetVersion" : "119.3.1",
+			"version" : "19.3.2",
+			"nugetVersion" : "119.3.2",
 			"nugetId" : "Xamarin.Firebase.Auth",
 			"dependencyOnly" : false
 		},
@@ -571,16 +571,16 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-config",
-			"version" : "19.1.4",
-			"nugetVersion" : "119.1.4",
+			"version" : "19.2.0",
+			"nugetVersion" : "119.2.0",
 			"nugetId" : "Xamarin.Firebase.Config",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-core",
-			"version" : "17.4.1",
-			"nugetVersion" : "117.4.1",
+			"version" : "17.4.4",
+			"nugetVersion" : "117.4.4",
 			"nugetId" : "Xamarin.Firebase.Core",
 			"dependencyOnly" : false
 		},
@@ -595,16 +595,16 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-crashlytics",
-			"version" : "17.1.0",
-			"nugetVersion" : "117.1.0",
+			"version" : "17.1.1",
+			"nugetVersion" : "117.1.1",
 			"nugetId" : "Xamarin.Firebase.Crashlytics",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-crashlytics-ndk",
-			"version" : "17.1.0",
-			"nugetVersion" : "117.1.0",
+			"version" : "17.1.1",
+			"nugetVersion" : "117.1.1",
 			"nugetId" : "Xamarin.Firebase.Crashlytics.NDK",
 			"dependencyOnly" : false
 		},
@@ -635,8 +635,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-datatransport",
-			"version" : "17.0.5",
-			"nugetVersion" : "117.0.5",
+			"version" : "17.0.6",
+			"nugetVersion" : "117.0.6",
 			"nugetId" : "Xamarin.Firebase.Datatransport",
 			"dependencyOnly" : false
 		},
@@ -659,8 +659,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-firestore",
-			"version" : "21.4.3",
-			"nugetVersion" : "121.4.3",
+			"version" : "21.5.0",
+			"nugetVersion" : "121.5.0",
 			"nugetId" : "Xamarin.Firebase.Firestore",
 			"dependencyOnly" : false
 		},
@@ -675,8 +675,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-iid",
-			"version" : "20.1.7",
-			"nugetVersion" : "120.1.7",
+			"version" : "20.2.4",
+			"nugetVersion" : "120.2.4",
 			"nugetId" : "Xamarin.Firebase.Iid",
 			"dependencyOnly" : false
 		},
@@ -691,24 +691,24 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-inappmessaging",
-			"version" : "19.0.6",
-			"nugetVersion" : "119.0.6",
+			"version" : "19.1.0",
+			"nugetVersion" : "119.1.0",
 			"nugetId" : "Xamarin.Firebase.InAppMessaging",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-inappmessaging-display",
-			"version" : "19.0.6",
-			"nugetVersion" : "119.0.6",
+			"version" : "19.1.0",
+			"nugetVersion" : "119.1.0",
 			"nugetId" : "Xamarin.Firebase.InAppMessaging.Display",
 			"dependencyOnly" : false
 		},
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-installations",
-			"version" : "16.3.0",
-			"nugetVersion" : "116.3.0",
+			"version" : "16.3.3",
+			"nugetVersion" : "116.3.3",
 			"nugetId" : "Xamarin.Firebase.Installations",
 			"dependencyOnly" : false
 		},
@@ -747,8 +747,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-messaging",
-			"version" : "20.1.7",
-			"nugetVersion" : "120.1.7",
+			"version" : "20.2.4",
+			"nugetVersion" : "120.2.4",
 			"nugetId" : "Xamarin.Firebase.Messaging",
 			"dependencyOnly" : false
 		},
@@ -875,8 +875,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "firebase-perf",
-			"version" : "19.0.7",
-			"nugetVersion" : "119.0.7",
+			"version" : "19.0.8",
+			"nugetVersion" : "119.0.8",
 			"nugetId" : "Xamarin.Firebase.Perf",
 			"dependencyOnly" : false
 		},
@@ -899,8 +899,8 @@
 		{
 			"groupId" : "com.google.firebase",
 			"artifactId" : "protolite-well-known-types",
-			"version" : "17.0.0",
-			"nugetVersion" : "117.0.0",
+			"version" : "17.1.0",
+			"nugetVersion" : "117.1.0",
 			"nugetId" : "Xamarin.Firebase.ProtoliteWellKnownTypes",
 			"dependencyOnly" : false
 		},
@@ -1086,6 +1086,14 @@
 			"dependencyOnly" : true
 		},
 		{
+			"groupId" : "com.google.protobuf",
+			"artifactId" : "protobuf-javalite",
+			"version" : "3.11.0",
+			"nugetVersion" : "3.11.0",
+			"nugetId" : "Xamarin.Protobuf.JavaLite",
+			"dependencyOnly" : true
+		},
+		{
 			"groupId" : "com.squareup.retrofit",
 			"artifactId" : "retrofit",
 			"version" : "1.9.0",			
@@ -1096,40 +1104,40 @@
 		{
 			"groupId" : "io.grpc",
 			"artifactId" : "grpc-protobuf-lite",
-			"version" : "1.21.1",
-			"nugetVersion" : "1.21.1",
+			"version" : "1.28.0",
+			"nugetVersion" : "1.28.0",
 			"nugetId" : "Xamarin.Grpc.Protobuf.Lite",
 			"dependencyOnly" : true
 		},
 		{
 			"groupId" : "io.grpc",
 			"artifactId" : "grpc-stub",
-			"version" : "1.21.1",
-			"nugetVersion" : "1.21.1",
+			"version" : "1.28.0",
+			"nugetVersion" : "1.28.0",
 			"nugetId" : "Xamarin.Grpc.Stub",
 			"dependencyOnly" : true
 		},
 		{
 			"groupId" : "io.grpc",
 			"artifactId" : "grpc-okhttp",
-			"version" : "1.21.1",
-			"nugetVersion" : "1.21.1",
+			"version" : "1.28.0",
+			"nugetVersion" : "1.28.0",
 			"nugetId" : "Xamarin.Grpc.OkHttp",
 			"dependencyOnly" : true
 		},
 		{
 			"groupId" : "io.grpc",
 			"artifactId" : "grpc-android",
-			"version" : "1.21.1",
-			"nugetVersion" : "1.21.1",
+			"version" : "1.28.0",
+			"nugetVersion" : "1.28.0",
 			"nugetId" : "Xamarin.Grpc.Android",
 			"dependencyOnly" : true
 		},
 		{
 			"groupId" : "com.google.auto.value",
 			"artifactId" : "auto-value-annotations",
-			"version" : "1.6.5",
-			"nugetVersion" : "1.6.5",
+			"version" : "1.6.6",
+			"nugetVersion" : "1.6.6",
 			"nugetId" : "Xamarin.Google.AutoValue.Annotations",
 			"dependencyOnly" : true
 		},
@@ -1144,8 +1152,8 @@
 		{
 			"groupId" : "com.google.dagger",
 			"artifactId" : "dagger",
-			"version" : "2.25.2.1",
-			"nugetVersion" : "2.25.2.1",
+			"version" : "2.27.0",
+			"nugetVersion" : "2.27.0",
 			"nugetId" : "Xamarin.Google.Dagger",
 			"dependencyOnly" : true
 		},
@@ -1208,8 +1216,8 @@
 		{
 			"groupId" : "com.google.android.datatransport",
 			"artifactId" : "transport-backend-cct",
-			"version" : "2.1.0",
-			"nugetVersion" : "2.1.0",
+			"version" : "2.3.0",
+			"nugetVersion" : "2.3.0",
 			"nugetId" : "Xamarin.Google.Android.DataTransport.TransportBackendCct",
 			"dependencyOnly" : true
 		},

--- a/source/com.google.android.gms/play-services-ads/Transforms/Metadata.xml
+++ b/source/com.google.android.gms/play-services-ads/Transforms/Metadata.xml
@@ -16,6 +16,7 @@
   	<attr path="/api/package[@name='com.google.android.gms.ads.mediation']" name="managedName">Android.Gms.Ads.Mediation</attr>
   	<attr path="/api/package[@name='com.google.android.gms.ads.mediation.admob']" name="managedName">Android.Gms.Ads.Mediation.Admob</attr>
   	<attr path="/api/package[@name='com.google.android.gms.ads.mediation.customevent']" name="managedName">Android.Gms.Ads.Mediation.CustomEvent</attr>
+  	<attr path="/api/package[@name='com.google.android.gms.ads.nonagon.transaction.omid']" name="managedName">Android.Gms.Ads.Nonagon.Transaction.Omid</attr>
   	<attr path="/api/package[@name='com.google.android.gms.ads.purchase']" name="managedName">Android.Gms.Ads.Purchase</attr>
   	<attr path="/api/package[@name='com.google.android.gms.ads.search']" name="managedName">Android.Gms.Ads.Search</attr>
   	<attr path="/api/package[@name='com.google.android.gms.internal']" name="managedName">Android.Gms.Internal</attr>

--- a/source/com.google.firebase/firebase-firestore/Transforms/Metadata.xml
+++ b/source/com.google.firebase/firebase-firestore/Transforms/Metadata.xml
@@ -25,6 +25,7 @@
 	<!-- These methods were using the explicit types instead of the expected Java.Lang.Object types for the interface -->
 	<attr path="/api/package[@name='com.google.firebase.firestore']/class[@name='GeoPoint']/method[@name='compareTo' and count(parameter)=1 and parameter[1][@type='com.google.firebase.firestore.GeoPoint']]/parameter[1]" name="managedType">Java.Lang.Object</attr>
 	<attr path="/api/package[@name='com.google.firebase.firestore']/class[@name='Blob']/method[@name='compareTo' and count(parameter)=1 and parameter[1][@type='com.google.firebase.firestore.Blob']]/parameter[1]" name="managedType">Java.Lang.Object</attr>
+	<attr path="/api/package[@name='com.google.firebase.firestore.core']/class[@name='MemoryComponentProvider']/method[@name='createConnectivityMonitor' and count(parameter)=1 and parameter[1][@type='com.google.firebase.firestore.core.ComponentProvider.Configuration']]" name="managedReturn">Firebase.Firestore.Remote.IConnectivityMonitor</attr>
 
 	<attr path="/api/package[@name='com.google.firebase.firestore']/interface[@name='EventListener']/method[@name='onEvent']/parameter[1]" name="managedName">obj</attr>
 	<attr path="/api/package[@name='com.google.firebase.firestore']/interface[@name='EventListener']/method[@name='onEvent']/parameter[2]" name="managedName">error</attr>
@@ -275,11 +276,32 @@
         
     <remove-node
         path="/api/package[@name='com.google.firebase.firestore.model.value']/class[@name='FieldValue']/method[@name='value' and count(parameter)=0]"
-        />    
-    <remove-node
-        path="/api/package[@name='com.google.firestore.v1']/class[@name='TransactionOptions']/implements[@name='com.google.firestore.v1.TransactionOptionsOrBuilder']"
-        />    
-    
+        />
+
+    <!--
+      These classes all contain nested classes with the same names as the desired property names from the "Builder" interface
+      they implement.  Thus they cannot implement the interface due to name conflicts.
+  -->
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='TransactionOptions']/implements[@name='com.google.firestore.v1.TransactionOptionsOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firebase.firestore.proto']/class[@name='MaybeDocument']/implements[@name='com.google.firebase.firestore.proto.MaybeDocumentOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firebase.firestore.proto']/class[@name='Target']/implements[@name='com.google.firebase.firestore.proto.TargetOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='BatchGetDocumentsRequest']/implements[@name='com.google.firestore.v1.BatchGetDocumentsRequestOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='BatchGetDocumentsResponse']/implements[@name='com.google.firestore.v1.BatchGetDocumentsResponseOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='MaybeDocument']/implements[@name='com.google.firestore.v1.BatchGetDocumentsResponseOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='DocumentTransform.FieldTransform']/implements[@name='com.google.firestore.v1.DocumentTransform.FieldTransformOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='GetDocumentRequest']/implements[@name='com.google.firestore.v1.GetDocumentRequestOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='ListDocumentsRequest']/implements[@name='com.google.firestore.v1.ListDocumentsRequestOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='ListenRequest']/implements[@name='com.google.firestore.v1.ListenRequestOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='ListenResponse']/implements[@name='com.google.firestore.v1.ListenResponseOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='Precondition']/implements[@name='com.google.firestore.v1.PreconditionOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='RunQueryRequest']/implements[@name='com.google.firestore.v1.RunQueryRequestOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='StructuredQuery.Filter']/implements[@name='com.google.firestore.v1.StructuredQuery.FilterOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='StructuredQuery.UnaryFilter']/implements[@name='com.google.firestore.v1.StructuredQuery.UnaryFilterOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='Target']/implements[@name='com.google.firestore.v1.TargetOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='Target.QueryTarget']/implements[@name='com.google.firestore.v1.Target.QueryTargetOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='TransactionOptions.ReadOnly']/implements[@name='com.google.firestore.v1.TransactionOptions.ReadOnlyOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='Value']/implements[@name='com.google.firestore.v1.ValueOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firestore.v1']/class[@name='Write']/implements[@name='com.google.firestore.v1.WriteOrBuilder']" />
 
 
     <attr

--- a/source/com.google.firebase/firebase-iid/Transforms/Metadata.xml
+++ b/source/com.google.firebase/firebase-iid/Transforms/Metadata.xml
@@ -19,4 +19,7 @@
 	<attr path="/api/package[@name='com.google.firebase.iid']/class[@name='zzb']" name="obfuscated">false</attr>
 
 	<remove-node path="/api/package[@name='com.google.android.gms.internal']" />
+
+  <!-- Conflicts with a nested class named "ErrorCode", so keep it "GetErrorCode" -->
+  <attr path="/api/package[@name='com.google.firebase.iid']/class[@name='MessengerIpcClient.RequestFailedException']/method[@name='getErrorCode' and count(parameter)=0]" name="propertyName"></attr>
 </metadata>

--- a/source/com.google.firebase/firebase-inappmessaging/Transforms/Metadata.xml
+++ b/source/com.google.firebase/firebase-inappmessaging/Transforms/Metadata.xml
@@ -243,6 +243,28 @@
         name="managedReturn"
         >
         Java.Lang.Object
-    </attr>        
-    
+    </attr>
+
+    <attr
+        path="/api/package[@name='com.google.firebase.inappmessaging.internal.injection.modules']/class[@name='ApiClientModule_ProvidesFirebaseInstallationsFactory']/method[@name='get' and count(parameter)=0]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>
+
+    <attr
+        path="/api/package[@name='com.google.firebase.inappmessaging.internal.injection.modules']/class[@name='TransportClientModule_ProvidesMetricsLoggerClientFactory']/method[@name='get' and count(parameter)=0]"
+        name="managedReturn"
+          >
+        Java.Lang.Object
+    </attr>
+
+    <!--
+      These classes all contain nested classes with the same names as the desired property names from the "Builder" interface
+      they implement.  Thus they cannot implement the interface due to name conflicts.
+    -->
+    <remove-node path="/api/package[@name='com.google.firebase.inappmessaging']/class[@name='CampaignAnalytics']/implements[@name='com.google.firebase.inappmessaging.CampaignAnalyticsOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firebase.inappmessaging']/class[@name='CommonTypesProto.TriggeringCondition']/implements[@name='com.google.firebase.inappmessaging.CommonTypesProto.TriggeringConditionOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.firebase.inappmessaging']/class[@name='MessagesProto.Content']/implements[@name='com.google.firebase.inappmessaging.MessagesProto.ContentOrBuilder']" />
+    <remove-node path="/api/package[@name='com.google.internal.firebase.inappmessaging.v1']/class[@name='CampaignProto.ThickContent']/implements[@name='com.google.internal.firebase.inappmessaging.v1.CampaignProto.ThickContentOrBuilder']" />
 </metadata>

--- a/source/com.google.firebase/protolite-well-known-types/Transforms/Metadata.xml
+++ b/source/com.google.firebase/protolite-well-known-types/Transforms/Metadata.xml
@@ -54,20 +54,35 @@
         >
         Firebase.ProtoliteWrapper
     </attr>
-  
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
+    <attr
+        path="/api/package[@name='com.google.geo.type']"
+        name="managedName"
+          >
+      Google.Geo.Type
+    </attr>
+    <attr
+        path="/api/package[@name='com.google.rpc.context']"
+        name="managedName"
+          >
+      Google.Rpc.Context
+    </attr>
 
-    <remove-node
+
+
+
+
+
+
+
+
+
+
+
+<!--
+    These classes all contain nested classes with the same names as the desired property names from the "Builder" interface
+    they implement.  Thus they cannot implement the interface due to name conflicts.
+-->
+  <remove-node
         path="/api/package[@name='com.google.protobuf']/class[@name='DescriptorProtos.UninterpretedOption.NamePart']/implements[@name='com.google.protobuf.DescriptorProtos.UninterpretedOption.NamePartOrBuilder']"
         />
     
@@ -75,4 +90,12 @@
         path="/api/package[@name='com.google.api']/class[@name='Distribution']/implements[@name='com.google.api.DistributionOrBuilder']"
         >
     </remove-node>
+
+  <remove-node path="/api/package[@name='com.google.api']/class[@name='BackendRule']/implements[@name='com.google.api.BackendRuleOrBuilder']" />
+  <remove-node path="/api/package[@name='com.google.api']/class[@name='Distribution.BucketOptions']/implements[@name='com.google.api.Distribution.BucketOptionsOrBuilder']" />
+  <remove-node path="/api/package[@name='com.google.api']/class[@name='HttpRule']/implements[@name='com.google.api.HttpRuleOrBuilder']" />
+  <remove-node path="/api/package[@name='com.google.longrunning']/class[@name='Operation']/implements[@name='com.google.longrunning.OperationOrBuilder']" />
+  <remove-node path="/api/package[@name='com.google.api']/class[@name='JwtLocation']/implements[@name='com.google.api.JwtLocationOrBuilder']" />
+  <remove-node path="/api/package[@name='com.google.rpc.context']/class[@name='AttributeContext']/implements[@name='com.google.rpc.context.AttributeContextOrBuilder']" />
+  <remove-node path="/api/package[@name='com.google.type']/class[@name='DateTime']/implements[@name='com.google.type.DateTimeOrBuilder']" />
 </metadata>


### PR DESCRIPTION
## Google Play Services
- com.google.android.gms.play-services-ads (19.1.0 -> 19.3.0)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617553/Xamarin.GooglePlayServices.Ads.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617554/Xamarin.GooglePlayServices.Ads.dll.diff.txt)
- com.google.android.gms.play-services-ads-base (19.1.0 -> 19.3.0)
  - No public API changes
- com.google.android.gms.play-services-ads-lite (19.1.0 -> 19.3.0)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617567/Xamarin.GooglePlayServices.Ads.Lite.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617569/Xamarin.GooglePlayServices.Ads.Lite.dll.diff.txt)
- com.google.android.gms.play-services-auth (18.0.0 -> 18.1.0)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617585/Xamarin.GooglePlayServices.Auth.dll.diff.txt)
- com.google.android.gms.play-services-cast (18.1.0 -> 19.0.0)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617597/Xamarin.GooglePlayServices.Cast.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617599/Xamarin.GooglePlayServices.Cast.dll.diff.txt)
- com.google.android.gms.play-services-cast-framework (18.1.0 -> 19.0.0)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617605/Xamarin.GooglePlayServices.Cast.Framework.dll.diff.txt)
- com.google.android.gms.play-services-gass (19.1.0 -> 19.3.0)
  - No public API changes
- com.google.android.gms.play-services-measurement (17.4.1 -> 17.4.4)
  - No public API changes
- com.google.android.gms.play-services-measurement-api (17.4.1 -> 17.4.4)
  - No public API changes
- com.google.android.gms.play-services-measurement-base (17.4.1 -> 17.4.4)
  - No public API changes
- com.google.android.gms.play-services-measurement-impl (17.4.1 -> 17.4.4)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617624/Xamarin.GooglePlayServices.Measurement.Impl.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617625/Xamarin.GooglePlayServices.Measurement.Impl.dll.diff.txt)
- com.google.android.gms.play-services-measurement-sdk (17.4.1 -> 17.4.4)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617628/Xamarin.GooglePlayServices.Measurement.Sdk.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617629/Xamarin.GooglePlayServices.Measurement.Sdk.dll.diff.txt)
- com.google.android.gms.play-services-measurement-sdk-api (17.4.1 -> 17.4.4)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617632/Xamarin.GooglePlayServices.Measurement.Sdk.Api.dll.diff.txt)

## Firebase
- com.google.firebase.firebase-abt (19.0.1 -> 19.1.0)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617665/Xamarin.Firebase.Abt.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617666/Xamarin.Firebase.Abt.dll.diff.txt)
- com.google.firebase.firebase-ads (19.1.0 -> 19.3.0)
  - No public API changes
- com.google.firebase.firebase-ads-lite (19.1.0 -> 19.3.0)
  - No public API changes
- com.google.firebase.firebase-analytics (17.4.1 -> 17.4.4)
  - No public API changes
- com.google.firebase.firebase-auth (19.3.1 -> 19.3.2)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617684/Xamarin.Firebase.Auth.dll.diff.txt)
- com.google.firebase.firebase-config (19.1.4 -> 19.2.0)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617699/Xamarin.Firebase.Config.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617700/Xamarin.Firebase.Config.dll.diff.txt)
- com.google.firebase.firebase-core (17.4.1 -> 17.4.4)
  - No public API changes
- com.google.firebase.firebase-crashlytics (17.1.0 -> 17.1.1)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617708/Xamarin.Firebase.Crashlytics.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617709/Xamarin.Firebase.Crashlytics.dll.diff.txt)
- com.google.firebase.firebase-crashlytics-ndk (17.1.0 -> 17.1.1)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617715/Xamarin.Firebase.Crashlytics.NDK.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617716/Xamarin.Firebase.Crashlytics.NDK.dll.diff.txt)
- com.google.firebase.firebase-datatransport (17.0.5 -> 17.0.6)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617726/Xamarin.Firebase.Datatransport.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617727/Xamarin.Firebase.Datatransport.dll.diff.txt)
- com.google.firebase.firebase-firestore (21.4.3 -> 21.5.0)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617739/Xamarin.Firebase.Firestore.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617741/Xamarin.Firebase.Firestore.dll.diff.txt)
- com.google.firebase.firebase-iid (20.1.7 -> 20.2.4)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617747/Xamarin.Firebase.Iid.dll.diff.txt)
- com.google.firebase.firebase-inappmessaging (19.0.6 -> 19.1.0)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617760/Xamarin.Firebase.InAppMessaging.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617761/Xamarin.Firebase.InAppMessaging.dll.diff.txt)
- com.google.firebase.firebase-inappmessaging-display (19.0.6 -> 19.1.0)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617762/Xamarin.Firebase.InAppMessaging.Display.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617763/Xamarin.Firebase.InAppMessaging.Display.dll.diff.txt)
- com.google.firebase.firebase-installations (16.3.0 -> 16.3.3)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617767/Xamarin.Firebase.Installations.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5617769/Xamarin.Firebase.Installations.dll.diff.txt)
- com.google.firebase.firebase-messaging (20.1.7 -> 20.2.4)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5618170/Xamarin.Firebase.Messaging.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5618171/Xamarin.Firebase.Messaging.dll.diff.txt)
- com.google.firebase.firebase-perf (19.0.7 -> 19.0.8)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5618175/Xamarin.Firebase.Perf.dll.diff.txt)
- com.google.firebase.protolite-well-known-types (17.0.0 -> 17.1.0)
  - [breaking.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5618176/Xamarin.Firebase.ProtoliteWellKnownTypes.dll.breaking.txt)
  - [diff.txt](https://github.com/xamarin/GooglePlayServicesComponents/files/5618178/Xamarin.Firebase.ProtoliteWellKnownTypes.dll.diff.txt)

## Potential Issues

### Obfuscation

I'm not sure if these are something we generally fix:

```
In: com.google.android.gms.play-services-ads-lite 

#### Type Changed: Android.Gms.Ads.AdSize

- public static AdSize Zzace { get; }
+ public static AdSize Zzacw { get; }
```

### Types Moved Namespace

`com.google.firebase.protolite-well-known-types` moved a lot of Protobuf types from itself to a dependent package `protobuf-lite`, such as `com.google.protobuf.any`.  The issue with this is we bound `protobuf-lite` with the namespace `Xamarin.Protobuf.Lite` instead of `Google.Protobuf`, so all these types are changing namespaces:

```
type: com.google.protobuf.any
- Google.Protobuf.Any
+ Xamarin.Protobuf.Lite.Any
```

This causes a lot of changes of types in some packages, like `com.google.firebase.firebase-firestore`:

```
#### Type Changed: Firebase.Firestore.Model.ServerTimestamps

- public static Google.Protobuf.Timestamp GetLocalWriteTime (Google.Firestore.V1.Value serverTimestampValue);
+ public static Xamarin.Protobuf.Lite.Timestamp GetLocalWriteTime (Google.Firestore.V1.Value serverTimestampValue);
```