### PR TITLE
[update-config.csx] Fix issue causing incorrect nuget version numbers for GPS.

### DIFF
--- a/build/scripts/update-config.csx
+++ b/build/scripts/update-config.csx
@@ -55,7 +55,7 @@ foreach (var art in config[0].Artifacts.Where(a => !a.DependencyOnly)) {
 		if (should_update)
 		{
 			var new_version = GetLatestVersion (a)?.ToString ();
-			var prefix = art.NugetVersion.StartsWith ("1" + art.Version + ".") ? "1" : string.Empty;
+			var prefix = art.NugetVersion.StartsWith ("1" + art.Version) ? "1" : string.Empty;
 
 			art.Version = new_version;
 			art.NugetVersion = prefix + new_version;


### PR DESCRIPTION
The new weekly stable update script has logic to detect GPS components that need to have 100 added to the version number (ie: `18.0.0` -> `118.0.0`), however there is a bug where it was checking for an additional period after the version, which will only happen when the existing nuget version contains 4 parts (`18.0.0.0` instead of `18.0.0`).  This PR removes that requirement so it should always work correctly.