### PR TITLE
Multi-target for .NET 6 and MonoAndroid90

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -9,6 +9,13 @@ pr:
 variables:
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
+  DotNetCoreVersion: 3.1.x
+  DotNet6Version: 6.0.100-alpha.1.21064.27
+  DotNet6AndroidMsi:  https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4410065/master/dc1f7ba5f6fd5ba19de9377014b1536487838397/Microsoft.NET.Workload.Android.11.0.200.50.msi
+  DotNet6AndroidPkg:  https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4410065/master/dc1f7ba5f6fd5ba19de9377014b1536487838397/Microsoft.NET.Workload.Android-11.0.200-ci.master.50.pkg
+  XamarinAndroidVsix: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4410065/master/dc1f7ba5f6fd5ba19de9377014b1536487838397/signed/Xamarin.Android.Sdk-11.2.99.50.vsix
+  XamarinAndroidPkg:  https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4410065/master/dc1f7ba5f6fd5ba19de9377014b1536487838397/xamarin.android-11.2.99.50.pkg
+  NugetSecurityAnalysisWarningLevel: warn
 #   XAMARIN_ANDROID_PATH: <path to Xamarin.Android>
 
 resources:
@@ -27,19 +34,46 @@ jobs:
     parameters:
       timeoutInMinutes: 240
       areaPath: 'DevDiv\Xamarin SDK\Android'
+      dotnet: ''
+      initSteps:
+        - task: UseDotNet@2
+          displayName: install .NET $(DotNetCoreVersion)
+          inputs:
+            version: $(DotNetCoreVersion)
+            installationPath: /usr/local/share/dotnet/
+          condition: eq(variables['System.JobName'], 'macos')
+        - bash: >
+            export DOTNET_ROOT=/usr/local/share/dotnet/ &&
+            export PATH="$DOTNET_ROOT:~/.dotnet/tools:$PATH" &&
+            curl -L https://dot.net/v1/dotnet-install.sh > dotnet-install.sh &&
+            sh dotnet-install.sh --version $(DotNet6Version) --install-dir $DOTNET_ROOT --verbose &&
+            dotnet --list-sdks &&
+            echo "##vso[task.setvariable variable=PATH]$PATH"
+          displayName: install .NET $(DotNet6Version)
+          condition: eq(variables['System.JobName'], 'macos')
+        - pwsh: |
+            $ProgressPreference = 'SilentlyContinue'
+            Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+            & .\dotnet-install.ps1 -Version $(DotNet6Version) -InstallDir "$env:ProgramFiles\dotnet\" -Verbose
+            & dotnet --list-sdks
+          displayName: install .NET $(DotNet6Version)
+          condition: eq(variables['System.JobName'], 'windows')
       preBuildSteps:
         - pwsh: |
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-8-macos
-          condition: eq(variables['System.JobName'], 'macos')
+          displayName: install .NET global tools
         - pwsh: |
-            dotnet tool uninstall --global Cake.Tool
-            dotnet tool install --global Cake.Tool
-            dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-8-windows
+            boots $(DotNet6AndroidPkg)
+            boots $(XamarinAndroidPkg)
+          condition: eq(variables['System.JobName'], 'macos')
+          displayName: install Xamarin.Android
+        - pwsh: |
+            boots $(DotNet6AndroidMsi)
+            boots $(XamarinAndroidVsix)
           condition: eq(variables['System.JobName'], 'windows')
+          displayName: install Xamarin.Android
       tools:
         - 'xamarin.androidbinderator.tool': '0.4.3'
         - 'xamarin.androidx.migration.tool': '1.0.7.1'

--- a/build.cake
+++ b/build.cake
@@ -483,18 +483,21 @@ Task("libs")
 
 	foreach(string config in Configs)
 	{
-		MSBuild("./generated/GooglePlayServices.sln", c => {
-			c.Configuration = config;
-			c.MaxCpuCount = MAX_CPU_COUNT;
-			c.BinaryLogger = new MSBuildBinaryLogSettings { Enabled = true, FileName = MakeAbsolute(new FilePath("./output/libs.binlog")).FullPath };
-			c.Properties.Add("DesignTimeBuild", new [] { "false" });
-			c.Properties.Add("AndroidSdkBuildToolsVersion", new [] { AndroidSdkBuildTools });
-			c.Restore = true;
-			if (! string.IsNullOrEmpty(ANDROID_HOME))
-			{
-				c.Properties.Add("AndroidSdkDirectory", new [] { $"{ANDROID_HOME}" } );
-			}
+		var settings = new DotNetCoreMSBuildSettings()
+			.SetConfiguration(config)
+			.SetMaxCpuCount(MAX_CPU_COUNT);
+		settings.Properties.Add("DesignTimeBuild", new [] { "false" });
+		settings.Properties.Add("AndroidSdkBuildToolsVersion", new [] { AndroidSdkBuildTools });
+		if (! string.IsNullOrEmpty(ANDROID_HOME))
+		{
+			settings.Properties.Add("AndroidSdkDirectory", new [] { $"{ANDROID_HOME}" } );
+		}
+
+		DotNetCoreRestore("./generated/GooglePlayServices.sln", new DotNetCoreRestoreSettings
+		{ 
+			MSBuildSettings = settings.EnableBinaryLogger("./output/restore.binlog")
 		});
+		DotNetCoreMSBuild("./generated/GooglePlayServices.sln", settings.EnableBinaryLogger("./output/libs.binlog"));
 	}
 });
 
@@ -670,23 +673,23 @@ Task("nuget")
 	.Does(() =>
 {
 	var outputPath = new DirectoryPath("./output");
+	var settings = new DotNetCoreMSBuildSettings()
+		.SetConfiguration("Release")
+		.SetMaxCpuCount(MAX_CPU_COUNT)
+		.EnableBinaryLogger ("./output/nuget.binlog");
+	settings.Targets.Clear();
+	settings.Targets.Add("Pack");
+	settings.Properties.Add("PackageOutputPath", new [] { MakeAbsolute(outputPath).FullPath });
+	settings.Properties.Add("PackageRequireLicenseAcceptance", new [] { "true" });
+	settings.Properties.Add("DesignTimeBuild", new [] { "false" });
+	settings.Properties.Add("AndroidSdkBuildToolsVersion", new [] { $"{AndroidSdkBuildTools}" });
 
-	MSBuild ("./generated/GooglePlayServices.sln", c => {
-		c.Configuration = "Release";
-		c.MaxCpuCount = MAX_CPU_COUNT;
-		c.BinaryLogger = new MSBuildBinaryLogSettings { Enabled = true, FileName = MakeAbsolute(new FilePath("./output/nuget.binlog")).FullPath };
-		c.Targets.Clear();
-		c.Targets.Add("Pack");
-		c.Properties.Add("PackageOutputPath", new [] { MakeAbsolute(outputPath).FullPath });
-		c.Properties.Add("PackageRequireLicenseAcceptance", new [] { "true" });
-		c.Properties.Add("DesignTimeBuild", new [] { "false" });
-		c.Properties.Add("AndroidSdkBuildToolsVersion", new [] { $"{AndroidSdkBuildTools}" });
+	if (! string.IsNullOrEmpty(ANDROID_HOME))
+	{
+		settings.Properties.Add("AndroidSdkDirectory", new[] { $"{ANDROID_HOME}" });
+	}
 
-		if (! string.IsNullOrEmpty(ANDROID_HOME))
-		{
-			c.Properties.Add("AndroidSdkDirectory", new[] { $"{ANDROID_HOME}" });
-		}
-    });
+	DotNetCoreMSBuild ("./generated/GooglePlayServices.sln", settings);
 });
 
 Task ("merge")

--- a/config.json
+++ b/config.json
@@ -940,7 +940,7 @@
         "groupId": "androidx.annotation",
         "artifactId": "annotation",
         "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
+        "nugetVersion": "1.1.0.4",
         "nugetId": "Xamarin.AndroidX.Annotation",
         "dependencyOnly": true
       },
@@ -1044,7 +1044,7 @@
         "groupId": "androidx.appcompat",
         "artifactId": "appcompat",
         "version": "1.2.0",
-        "nugetVersion": "1.2.0",
+        "nugetVersion": "1.2.0.2",
         "nugetId": "Xamarin.AndroidX.AppCompat",
         "dependencyOnly": true
       },

--- a/generated/global.json
+++ b/generated/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "version": "6.0.100-alpha.1.21064.27",
+        "rollForward": "disable",
+        "allowPrerelease": true
+    }
+}

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+    <add key="xamarin" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
+    <add key="nuget"   value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <config>
+    <add key="globalPackagesFolder" value="packages" />
+  </config>
+</configuration>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -111,7 +111,7 @@
     <PackageReference Update="Xamarin.Firebase.ProtoliteWellKnownTypes" Version="117.0.0" />
     <PackageReference Update="Xamarin.Google.Guava" Version="" />
     <PackageReference Update="Xamarin.Google.Guava.ListenableFuture" Version="1.0.0.2" />
-    <PackageReference Update="Xamarin.AndroidX.Annotation" Version="1.1.0.1" />
+    <PackageReference Update="Xamarin.AndroidX.Annotation" Version="1.1.0.4" />
     <PackageReference Update="Xamarin.AndroidX.Browser" Version="1.2.0.1" />
     <PackageReference Update="Xamarin.AndroidX.Collection" Version="1.1.0.1" />
     <PackageReference Update="Xamarin.AndroidX.Core" Version="1.2.0.1" />

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -2,29 +2,20 @@
 @using System.Collections.Generic
 
 @{
-  var targetFrameworkMoniker = "MonoAndroid90";
+  var targetFrameworkMoniker = "monoandroid90";
+  var dotnetFrameworkMoniker = "net6.0-android30.0";
 }
 
-<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
+<Project Sdk="Xamarin.Legacy.Sdk/0.1.0-alpha1">
   <PropertyGroup>
-    <TargetFramework>@(targetFrameworkMoniker)</TargetFramework>
+    <TargetFrameworks>@(targetFrameworkMoniker);@(dotnetFrameworkMoniker)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     @if (!string.IsNullOrEmpty(Model.AssemblyName)) {
     <AssemblyName>@(Model.AssemblyName)</AssemblyName>
     } else {
     <AssemblyName>@(Model.NuGetPackageId)</AssemblyName>
     }
-    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
-    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
-    <EnableProguard>true</EnableProguard>
-    <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
-    <AndroidUseAapt2>true</AndroidUseAapt2>
-    <AndroidDexTool>d8</AndroidDexTool>
-    <AndroidLinkTool>r8</AndroidLinkTool>
-    <AndroidManifestMerger>manifestmerger.jar</AndroidManifestMerger>
+    <AndroidUseIntermediateDesignerFile>false</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>
 
   @{
@@ -107,15 +98,6 @@
     <NoWarn>08A04;BG8A00</NoWarn>
 
     <!--
-      Harmfull 
-      - BG8401: Skipping managed_type, due to a duplicate field, method or nested type name. (Nested type) (Java type: java_type)  
-      - BG8604: top ancestor Type1 not found for nested type Namespace.Type1.Type2
-      - BG8C00: For type Namespace.Type1, base interface java.Interface does not exist
-      - BG8700: Unknown return type java.Type1 in method Method1 in managed type Namespace.Type2.
-      - BG8800: Unknown parameter type java.Type1 in method Method2 in managed type Namespace.Type2.
-    -->
-    <WarningsAsErrors>BG8401;BG8604;BG8C00;BG8700;BG8800</WarningsAsErrors>
-    <!--
       Xamarin.Android specific warnings
       =================================================================================================================
     -->
@@ -147,12 +129,14 @@
 
   <ItemGroup>
     <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\@(targetFrameworkMoniker)" />
+    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\@(dotnetFrameworkMoniker)" />
   </ItemGroup>
 
   @if (@Model.NuGetPackageId == "Xamarin.GooglePlayServices.Basement")
   {
     <ItemGroup>
       <None Include="..\..\source\com.google.android.gms\play-services-basement\buildtasks\bin\$(Configuration)\Xamarin.GooglePlayServices.Tasks.dll" Pack="True" PackagePath="build\@(targetFrameworkMoniker)" />
+      <None Include="..\..\source\com.google.android.gms\play-services-basement\buildtasks\bin\$(Configuration)\Xamarin.GooglePlayServices.Tasks.dll" Pack="True" PackagePath="build\@(dotnetFrameworkMoniker)" />
     </ItemGroup>
   }
 
@@ -160,7 +144,7 @@
   <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) {
       if (art.ProguardFile != null) {
-    <None Include="..\..\@(art.ProguardFile)" Pack="True" PackagePath="proguard\@(targetFrameworkMoniker)" />
+    <None Include="..\..\@(art.ProguardFile)" Pack="True" PackagePath="proguard" />
       }
     }
   </ItemGroup>
@@ -190,7 +174,7 @@
   <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) {
       if (1==2 && art.MavenArtifactPackaging == "aar") {
-    <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).aar" Pack="True" PackagePath="aar\@(targetFrameworkMoniker)" />
+    <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).aar" Pack="True" PackagePath="aar" />
       }
     }
   </ItemGroup>
@@ -251,7 +235,8 @@
       <PackageReference Include="Xamarin.Google.Dagger" Version="2.25.2.1" />
     }
 
-
+    <!-- Reference -->
+    <Reference Include="System.Net.Http" Condition=" '$(TargetFramework)' == '@(targetFrameworkMoniker)' " />
   </ItemGroup>
 
 

--- a/source/GooglePlayServicesTargets.cshtml
+++ b/source/GooglePlayServicesTargets.cshtml
@@ -1,9 +1,7 @@
 @using System.Linq
 @using System.IO
 @using System.Xml.Linq
-@{
-  var targetFrameworkMoniker = "MonoAndroid90";
-}
+
 <?xml version="1.0" encoding="utf-8"?>
 @functions {
   public static void RemoveXmlns(XElement e)
@@ -27,7 +25,7 @@
   <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) {
       if (art.ProguardFile != null) {
-    <ProguardConfiguration Include="$(MSBuildThisFileDirectory)..\..\proguard\@(targetFrameworkMoniker)\proguard.txt" />
+    <ProguardConfiguration Include="$(MSBuildThisFileDirectory)..\..\proguard\proguard.txt" />
       }
     }
   </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/Xamarin.Legacy.Sdk

This uses Xamarin.Legacy.Sdk to multi-target.

For this to work:

* You have to use `dotnet build` to build any `Xamarin.Legacy.Sdk`
  projects. Windows can use `MSBuild.exe` from Visual Studio 16.9
  Preview 4 as well.

The CI build will also have to install:

* .NET 6.0.100-alpha.1.21064.27
* Microsoft.NET.Android.Workload 11.0.200.50
* Xamarin.Android 11.2.99.50

Other notes:

* Class libraries had application properties set like
  `$(EnableProguard)`, `$(AndroidEnableMultiDex)`,
  `$(AndroidDexTool)`, `$(AndroidLinkTool)`, etc.