### PR TITLE
116.3.0 old skipped artifacts

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -593,8 +593,8 @@ Task("samples")
 		EnsureDirectoryExists($@"./output/failed/");
 
 		var sampleSlns = GetFiles("./samples/all/**/*.sln")
-							.Concat(GetFiles("./samples/com.google.android.gms/**/*.sln"))
-							.Concat(GetFiles("./samples/com.google.firebase/**/*.sln"))
+							// .Concat(GetFiles("./samples/com.google.android.gms/**/*.sln"))
+							// .Concat(GetFiles("./samples/com.google.firebase/**/*.sln"))
 							;
 
 		foreach(string config in Configs)
@@ -658,11 +658,11 @@ Task("samples")
 			}
 		}
 
-		DeleteFiles(".output/system.*/nupkg");
-		DeleteFiles(".output/microsoft.*/nupkg");
-		DeleteFiles(".output/xamarin.android.support.*/nupkg");
-		DeleteFiles(".output/xamarin.android.arch.*/nupkg");
-		DeleteFiles(".output/xamarin.build.download.*/nupkg");
+		DeleteFiles("./output/system.*/nupkg");
+		DeleteFiles("./output/microsoft.*/nupkg");
+		DeleteFiles("./output/xamarin.android.support.*/nupkg");
+		DeleteFiles("./output/xamarin.android.arch.*/nupkg");
+		DeleteFiles("./output/xamarin.build.download.*/nupkg");
 });
 
 Task("allbindingprojectrefs")

--- a/source/com.google.android.gms/play-services-base/Additions/ResultCallbackImpl.cs
+++ b/source/com.google.android.gms/play-services-base/Additions/ResultCallbackImpl.cs
@@ -77,12 +77,14 @@ namespace Android.Gms.Common.Apis
 
             public Builder EnableAutoManage(AndroidX.Fragment.App.FragmentActivity fragmentActivity, int clientId, Action<Android.Gms.Common.ConnectionResult> unresolvedConnectionFailedHandler)
             {
-                return EnableAutoManage(fragmentActivity, clientId, new GoogleApiClientOnConnectionFailedListenerImpl(unresolvedConnectionFailedHandler));
+                // return EnableAutoManage(fragmentActivity, clientId, new GoogleApiClientOnConnectionFailedListenerImpl(unresolvedConnectionFailedHandler));
+                return EnableAutoManage(fragmentActivity, clientId, new System.Action<Android.Gms.Common.ConnectionResult>(unresolvedConnectionFailedHandler));
             }
 
             public Builder EnableAutoManage(AndroidX.Fragment.App.FragmentActivity fragmentActivity, Action<Android.Gms.Common.ConnectionResult> unresolvedConnectionFailedHandler)
             {
-                return EnableAutoManage(fragmentActivity, new GoogleApiClientOnConnectionFailedListenerImpl(unresolvedConnectionFailedHandler));
+                // return EnableAutoManage(fragmentActivity, new GoogleApiClientOnConnectionFailedListenerImpl(unresolvedConnectionFailedHandler));
+                return EnableAutoManage(fragmentActivity, new System.Action<Android.Gms.Common.ConnectionResult>(unresolvedConnectionFailedHandler));
             }
         }
     }


### PR DESCRIPTION
### Google Play Services Version (eg: 1xx):

Adding older artifacts 16.x.x which were skipped during initial upgrade to 1xx (AndroidX)

### Does this change any of the generated binding API's?


### Describe your contribution
