### PR TITLE
Clean up build dependencies

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,6 +24,9 @@
       }
     ],
     "artifacts": [
+
+      // Artifacts built as part of this repository ("dependencyOnly": false)
+
       {
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-ads",
@@ -930,6 +933,14 @@
       },
       {
         "groupId": "com.google.firebase",
+        "artifactId": "protolite-well-known-types",
+        "version": "17.1.1",
+        "nugetVersion": "117.1.1",
+        "nugetId": "Xamarin.Firebase.ProtoliteWellKnownTypes",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "com.google.firebase",
         "artifactId": "firebase-storage",
         "version": "19.2.1",
         "nugetVersion": "119.2.1",
@@ -945,18 +956,10 @@
         "dependencyOnly": false
       },
       {
-        "groupId": "com.google.firebase",
-        "artifactId": "protolite-well-known-types",
-        "version": "17.1.1",
-        "nugetVersion": "117.1.1",
-        "nugetId": "Xamarin.Firebase.ProtoliteWellKnownTypes",
-        "dependencyOnly": false
-      },
-      {
         "groupId": "com.google.android.play",
         "artifactId": "core",
         "version": "1.9.1",
-        "nugetVersion": "1.9.1",
+        "nugetVersion": "01.9.1",
         "nugetId": "Xamarin.Google.Android.Play.Core",
         "dependencyOnly": false
       },
@@ -1136,11 +1139,303 @@
         "nugetId": "Xamarin.Google.MLKit.Vision.Internal.Vkp",
         "dependencyOnly": false
       },
+
+      // External dependencies ("dependencyOnly": true)
+
+      {
+        "groupId": "com.google.android.gms",
+        "artifactId": "play-services-measurement-api",
+        "version": "16.3.0",
+        "nugetVersion": "71.1630.4",
+        "nugetId": "Xamarin.GooglePlayServices.Measurement.Api",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.android.gms",
+        "artifactId": "play-services-measurement-base",
+        "version": "16.3.0",
+        "nugetVersion": "71.1630.4",
+        "nugetId": "Xamarin.GooglePlayServices.Measurement.Base",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.firebase",
+        "artifactId": "firebase-analytics",
+        "version": "16.3.0",
+        "nugetVersion": "71.1630.4",
+        "nugetId": "Xamarin.Firebase.Analytics",
+        "dependencyOnly": true
+      },
+
+      {
+        "groupId": "com.squareup.okhttp",
+        "artifactId": "okhttp",
+        "version": "2.7.5",
+        "nugetVersion": "2.7.5.1",
+        "nugetId": "Square.OkHttp",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.squareup.okhttp3",
+        "artifactId": "okhttp",
+        "version": "4.8.1",
+        "nugetVersion": "4.8.1",
+        "nugetId": "Square.OkHttp3",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.squareup.okhttp3",
+        "artifactId": "okhttp-urlconnection",
+        "version": "4.8.1",
+        "nugetVersion": "4.8.1",
+        "nugetId": "Square.OkHttp3",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.squareup.picasso",
+        "artifactId": "picasso",
+        "version": "2.71828.0",
+        "nugetVersion": "2.71828.0",
+        "nugetId": "Square.Picasso",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.squareup.retrofit",
+        "artifactId": "retrofit",
+        "version": "1.9.0",
+        "nugetVersion": "1.9.0.1",
+        "nugetId": "Square.Retrofit",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "android.arch.lifecycle",
+        "artifactId": "common",
+        "version": "1.1.1",
+        "nugetVersion": "1.1.1.3",
+        "nugetId": "Xamarin.Android.Arch.Lifecycle.Common",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "android.arch.lifecycle",
+        "artifactId": "runtime",
+        "version": "1.1.1",
+        "nugetVersion": "1.1.1.3",
+        "nugetId": "Xamarin.Android.Arch.Lifecycle.Runtime",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "io.reactivex.rxjava2",
+        "artifactId": "rxandroid",
+        "version": "2.1.1",
+        "nugetVersion": "2.1.1",
+        "nugetId": "Xamarin.Android.ReactiveX.RxAndroid",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "io.reactivex.rxjava2",
+        "artifactId": "rxjava",
+        "version": "2.2.9",
+        "nugetVersion": "2.2.9",
+        "nugetId": "Xamarin.Android.ReactiveX.RxJava",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.annotation",
+        "artifactId": "annotation",
+        "version": "1.1.0",
+        "nugetVersion": "1.1.0.9",
+        "nugetId": "Xamarin.AndroidX.Annotation",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.appcompat",
+        "artifactId": "appcompat",
+        "version": "1.2.0",
+        "nugetVersion": "1.2.0.7",
+        "nugetId": "Xamarin.AndroidX.AppCompat",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.browser",
+        "artifactId": "browser",
+        "version": "1.3.0",
+        "nugetVersion": "1.3.0.5",
+        "nugetId": "Xamarin.AndroidX.Browser",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.cardview",
+        "artifactId": "cardview",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0.8",
+        "nugetId": "Xamarin.AndroidX.CardView",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.collection",
+        "artifactId": "collection",
+        "version": "1.1.0",
+        "nugetVersion": "1.1.0.7",
+        "nugetId": "Xamarin.AndroidX.Collection",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.constraintlayout",
+        "artifactId": "constraintlayout",
+        "version": "2.0.4",
+        "nugetVersion": "2.0.4.2",
+        "nugetId": "Xamarin.AndroidX.ConstraintLayout",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.core",
+        "artifactId": "core",
+        "version": "1.3.2",
+        "nugetVersion": "1.3.2.3",
+        "nugetId": "Xamarin.AndroidX.Core",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.exifinterface",
+        "artifactId": "exifinterface",
+        "version": "1.3.2",
+        "nugetVersion": "1.3.2.2",
+        "nugetId": "Xamarin.AndroidX.ExifInterface",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.fragment",
+        "artifactId": "fragment",
+        "version": "1.3.0",
+        "nugetVersion": "1.3.0.1",
+        "nugetId": "Xamarin.AndroidX.Fragment",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.legacy",
+        "artifactId": "legacy-support-core-utils",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0.7",
+        "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.Utils",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.legacy",
+        "artifactId": "legacy-support-v4",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0.7",
+        "nugetId": "Xamarin.AndroidX.Legacy.Support.V4",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.lifecycle",
+        "artifactId": "lifecycle-extensions",
+        "version": "2.2.0",
+        "nugetVersion": "2.2.0.7",
+        "nugetId": "Xamarin.AndroidX.Lifecycle.Extensions",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.loader",
+        "artifactId": "loader",
+        "version": "1.1.0",
+        "nugetVersion": "1.1.0.7",
+        "nugetId": "Xamarin.AndroidX.Loader",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.localbroadcastmanager",
+        "artifactId": "localbroadcastmanager",
+        "version": "1.0.0",
+        "nugetVersion": "1.0.0.7",
+        "nugetId": "Xamarin.AndroidX.LocalBroadcastManager",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.media",
+        "artifactId": "media",
+        "version": "1.2.1",
+        "nugetVersion": "1.2.1.2",
+        "nugetId": "Xamarin.AndroidX.Media",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.mediarouter",
+        "artifactId": "mediarouter",
+        "version": "1.2.2",
+        "nugetVersion": "1.2.2.1",
+        "nugetId": "Xamarin.AndroidX.MediaRouter",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.recyclerview",
+        "artifactId": "recyclerview",
+        "version": "1.1.0",
+        "nugetVersion": "1.1.0.8",
+        "nugetId": "Xamarin.AndroidX.RecyclerView",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "androidx.work",
+        "artifactId": "work-runtime",
+        "version": "2.5.0",
+        "nugetVersion": "2.5.0.1",
+        "nugetId": "Xamarin.AndroidX.Work.Runtime",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "org.chromium.net",
+        "artifactId": "cronet-api",
+        "version": "76.3809.111",
+        "nugetVersion": "76.3809.111",
+        "nugetId": "Xamarin.Chromium.CroNet.Api",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.android.datatransport",
+        "artifactId": "transport-api",
+        "version": "2.2.1",
+        "nugetVersion": "2.2.1",
+        "nugetId": "Xamarin.Google.Android.DataTransport.TransportApi",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.android.datatransport",
+        "artifactId": "transport-backend-cct",
+        "version": "2.3.3",
+        "nugetVersion": "2.3.3",
+        "nugetId": "Xamarin.Google.Android.DataTransport.TransportBackendCct",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.android.datatransport",
+        "artifactId": "transport-runtime",
+        "version": "2.2.5",
+        "nugetVersion": "2.2.5",
+        "nugetId": "Xamarin.Google.Android.DataTransport.TransportRuntime",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.auto.value",
+        "artifactId": "auto-value-annotations",
+        "version": "1.6.6",
+        "nugetVersion": "1.6.6",
+        "nugetId": "Xamarin.Google.AutoValue.Annotations",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.dagger",
+        "artifactId": "dagger",
+        "version": "2.27.0",
+        "nugetVersion": "2.27.0",
+        "nugetId": "Xamarin.Google.Dagger",
+        "dependencyOnly": true
+      },
       {
         "groupId": "com.google.guava",
         "artifactId": "guava",
-        "version": "27.1.0.3",
-        "nugetVersion": null,
+        "version": "28.2.0",
+        "nugetVersion": "28.2.0",
         "nugetId": "Xamarin.Google.Guava",
         "dependencyOnly": true
       },
@@ -1153,187 +1448,19 @@
         "dependencyOnly": true
       },
       {
-        "groupId": "androidx.annotation",
-        "artifactId": "annotation",
-        "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
-        "nugetId": "Xamarin.AndroidX.Annotation",
+        "groupId": "io.grpc",
+        "artifactId": "grpc-android",
+        "version": "1.28.0",
+        "nugetVersion": "1.28.0",
+        "nugetId": "Xamarin.Grpc.Android",
         "dependencyOnly": true
       },
       {
-        "groupId": "androidx.browser",
-        "artifactId": "browser",
-        "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
-        "nugetId": "Xamarin.AndroidX.Browser",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.collection",
-        "artifactId": "collection",
-        "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
-        "nugetId": "Xamarin.AndroidX.Collection",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.core",
-        "artifactId": "core",
-        "version": "1.2.0",
-        "nugetVersion": "1.2.0.1",
-        "nugetId": "Xamarin.AndroidX.Core",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.fragment",
-        "artifactId": "fragment",
-        "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
-        "nugetId": "Xamarin.AndroidX.Fragment",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.legacy",
-        "artifactId": "legacy-support-core-utils",
-        "version": "1.0.0",
-        "nugetVersion": "1.0.0.1",
-        "nugetId": "Xamarin.AndroidX.Legacy.Support.Core.Utils",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.lifecycle",
-        "artifactId": "lifecycle-extensions",
-        "version": "2.1.0",
-        "nugetVersion": "2.1.0.1",
-        "nugetId": "Xamarin.AndroidX.Lifecycle.Extensions",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.loader",
-        "artifactId": "loader",
-        "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
-        "nugetId": "Xamarin.AndroidX.Loader",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.mediarouter",
-        "artifactId": "mediarouter",
-        "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
-        "nugetId": "Xamarin.AndroidX.MediaRouter",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.media",
-        "artifactId": "media",
-        "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
-        "nugetId": "Xamarin.AndroidX.Media",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.recyclerview",
-        "artifactId": "recyclerview",
-        "version": "1.1.0",
-        "nugetVersion": "1.1.0.1",
-        "nugetId": "Xamarin.AndroidX.RecyclerView",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.localbroadcastmanager",
-        "artifactId": "localbroadcastmanager",
-        "version": "1.0.0",
-        "nugetVersion": "1.0.0.1",
-        "nugetId": "Xamarin.AndroidX.LocalBroadcastManager",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.exifinterface",
-        "artifactId": "exifinterface",
-        "version": "1.0.0",
-        "nugetVersion": "1.0.0.1",
-        "nugetId": "Xamarin.AndroidX.ExifInterface",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.appcompat",
-        "artifactId": "appcompat",
-        "version": "1.2.0",
-        "nugetVersion": "1.2.0",
-        "nugetId": "Xamarin.AndroidX.AppCompat",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.cardview",
-        "artifactId": "cardview",
-        "version": "1.0.0",
-        "nugetVersion": "1.0.0.1",
-        "nugetId": "Xamarin.AndroidX.CardView",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.constraintlayout",
-        "artifactId": "constraintlayout",
-        "version": "1.1.3",
-        "nugetVersion": "1.1.3.1",
-        "nugetId": "Xamarin.AndroidX.ConstraintLayout",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.legacy",
-        "artifactId": "legacy-support-v4",
-        "version": "1.0.0",
-        "nugetVersion": "1.0.0.1",
-        "nugetId": "Xamarin.AndroidX.Legacy.Support.V4",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "androidx.work",
-        "artifactId": "work-runtime",
-        "version": "2.4.0",
-        "nugetVersion": "2.4.0",
-        "nugetId": "Xamarin.AndroidX.Work.Runtime",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.squareup.okhttp",
-        "artifactId": "okhttp",
-        "version": "2.7.5",
-        "nugetVersion": "2.7.5.1",
-        "nugetId": "Square.OkHttp",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "org.tensorflow",
-        "artifactId": "tensorflow-lite",
-        "version": "2.1.0",
-        "nugetVersion": "2.1.0.1",
-        "nugetId": "Xamarin.TensorFlow.Lite",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.protobuf",
-        "artifactId": "protobuf-lite",
-        "version": "3.0.1",
-        "nugetVersion": "3.0.1",
-        "nugetId": "Xamarin.Protobuf.Lite",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.protobuf",
-        "artifactId": "protobuf-javalite",
-        "version": "3.14.0",
-        "nugetVersion": "3.14.0",
-        "nugetId": "Xamarin.Protobuf.JavaLite",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.squareup.retrofit",
-        "artifactId": "retrofit",
-        "version": "1.9.0",
-        "nugetVersion": "1.9.0",
-        "nugetId": "Square.Retrofit",
+        "groupId": "io.grpc",
+        "artifactId": "grpc-okhttp",
+        "version": "1.28.0",
+        "nugetVersion": "1.28.0",
+        "nugetId": "Xamarin.Grpc.OkHttp",
         "dependencyOnly": true
       },
       {
@@ -1353,259 +1480,35 @@
         "dependencyOnly": true
       },
       {
-        "groupId": "io.grpc",
-        "artifactId": "grpc-okhttp",
-        "version": "1.28.0",
-        "nugetVersion": "1.28.0",
-        "nugetId": "Xamarin.Grpc.OkHttp",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "io.grpc",
-        "artifactId": "grpc-android",
-        "version": "1.28.0",
-        "nugetVersion": "1.28.0",
-        "nugetId": "Xamarin.Grpc.Android",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.auto.value",
-        "artifactId": "auto-value-annotations",
-        "version": "1.6.6",
-        "nugetVersion": "1.6.6",
-        "nugetId": "Xamarin.Google.AutoValue.Annotations",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.squareup.okhttp3",
-        "artifactId": "okhttp",
-        "version": "3.12.3",
-        "nugetVersion": "3.12.3",
-        "nugetId": "Square.OkHttp3",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.squareup.okhttp3",
-        "artifactId": "okhttp-urlconnection",
-        "version": "4.3.1",
-        "nugetVersion": "4.3.1",
-        "nugetId": "Square.OkHttp3",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.dagger",
-        "artifactId": "dagger",
-        "version": "2.27.0",
-        "nugetVersion": "2.27.0",
-        "nugetId": "Xamarin.Google.Dagger",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "android.arch.lifecycle",
-        "artifactId": "common",
-        "version": "1.1.1.1",
-        "nugetVersion": "1.1.1.1",
-        "nugetId": "Xamarin.Android.Arch.Lifecycle.Common",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "android.arch.lifecycle",
-        "artifactId": "runtime",
-        "version": "1.1.1.1",
-        "nugetVersion": "1.1.1.1",
-        "nugetId": "Xamarin.Android.Arch.Lifecycle.Runtime",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.gms",
-        "artifactId": "play-services-measurement-base",
-        "version": "16.3.0",
-        "nugetVersion": "71.1630.1",
-        "nugetId": "Xamarin.GooglePlayServices.Measurement.Base",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "org.chromium.net",
-        "artifactId": "cronet-api",
-        "version": "75.3770.101",
-        "nugetVersion": "75.3770.101",
-        "nugetId": "Xamarin.Chromium.CroNet.Api",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-api",
-        "version": "2.2.1",
-        "nugetVersion": "2.2.1",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportApi",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-runtime",
-        "version": "2.2.4",
-        "nugetVersion": "2.2.4",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportRuntime",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-backend-cct",
-        "version": "2.3.1",
-        "nugetVersion": "2.3.1",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportBackendCct",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-api",
-        "version": "2.2.0",
-        "nugetVersion": "2.2.0",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportApi",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-runtime",
-        "version": "2.2.5",
-        "nugetVersion": "2.2.5",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportRuntime",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-backend-cct",
-        "version": "2.2.1",
-        "nugetVersion": "2.2.1",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportBackendCct",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-api",
-        "version": "2.2.0",
-        "nugetVersion": "2.2.0",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportApi",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-runtime",
-        "version": "2.2.2",
-        "nugetVersion": "2.2.2",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportRuntime",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-backend-cct",
-        "version": "2.2.2",
-        "nugetVersion": "2.2.2",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportBackendCct",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-runtime",
-        "version": "2.2.3",
-        "nugetVersion": "2.2.3",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportRuntime",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.datatransport",
-        "artifactId": "transport-backend-cct",
-        "version": "2.3.3",
-        "nugetVersion": "2.3.3",
-        "nugetId": "Xamarin.Google.Android.DataTransport.TransportBackendCct",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.dagger",
-        "artifactId": "dagger",
-        "version": "2.25.2",
-        "nugetVersion": "2.25.2",
-        "nugetId": "Xamarin.Google.Dagger",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "io.reactivex.rxjava2",
-        "artifactId": "rxandroid",
-        "version": "2.1.1",
-        "nugetVersion": "2.1.1",
-        "nugetId": "Xamarin.Android.ReactiveX.RxAndroid",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "io.reactivex.rxjava2",
-        "artifactId": "rxjava",
-        "version": "2.2.7",
-        "nugetVersion": "2.2.7",
-        "nugetId": "Xamarin.Android.ReactiveX.RxJava",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.squareup.picasso",
-        "artifactId": "picasso",
-        "version": "2.71828",
-        "nugetVersion": "2.71828",
-        "nugetId": "Square.Picasso",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.gms",
-        "artifactId": "play-services-measurement-api",
-        "version": "16.3.0",
-        "nugetVersion": "71.1630.1",
-        "nugetId": "Xamarin.GooglePlayServices.Measurement.Api",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-analytics",
-        "version": "16.3.0",
-        "nugetVersion": "71.1630.1",
-        "nugetId": "Xamarin.Firebase.Analytics",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.gms",
-        "artifactId": "play-services-vision-common",
-        "version": "19.0.0",
-        "nugetVersion": "119.0.0-preview03",
-        "nugetId": "Xamarin.GooglePlayServices.Vision.Common",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.android.gms",
-        "artifactId": "play-services-vision",
-        "version": "19.0.0",
-        "nugetVersion": "119.0.0-preview03",
-        "nugetId": "Xamarin.GooglePlayServices.Vision",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-analytics",
-        "version": "16.3.0",
-        "nugetVersion": "71.1630.1",
-        "nugetId": "Xamarin.Firebase.Analytics",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "com.google.firebase",
-        "artifactId": "firebase-iid",
-        "version": "19.0.1",
-        "nugetVersion": "119.0.1-preview03",
-        "nugetId": "Xamarin.Firebase.Iid",
-        "dependencyOnly": true
-      },
-      {
         "groupId": "javax.inject",
         "artifactId": "javax.inject",
         "version": "1.0.0",
         "nugetVersion": "1.0.0",
         "nugetId": "Xamarin.JavaX.Inject",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.protobuf",
+        "artifactId": "protobuf-javalite",
+        "version": "3.14.0",
+        "nugetVersion": "3.14.0",
+        "nugetId": "Xamarin.Protobuf.JavaLite",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.protobuf",
+        "artifactId": "protobuf-lite",
+        "version": "3.0.1",
+        "nugetVersion": "3.0.1",
+        "nugetId": "Xamarin.Protobuf.Lite",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "org.tensorflow",
+        "artifactId": "tensorflow-lite",
+        "version": "2.1.0",
+        "nugetVersion": "2.1.0.1",
+        "nugetId": "Xamarin.TensorFlow.Lite",
         "dependencyOnly": true
       }
     ]

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -1,5 +1,8 @@
 <Project>
   <ItemGroup>
+
+    <!-- Artifacts built as part of this repository ("dependencyOnly": false) -->
+
     <PackageReference Update="Xamarin.GooglePlayServices.Ads" Version="119.7.0" />
     <PackageReference Update="Xamarin.GooglePlayServices.Ads.Base" Version="119.7.0" />
     <PackageReference Update="Xamarin.GooglePlayServices.Ads.Identifier" Version="117.0.0" />
@@ -113,10 +116,10 @@
     <PackageReference Update="Xamarin.Firebase.ML.Vision.Internal.Vkp" Version="117.0.2" />
     <PackageReference Update="Xamarin.Firebase.ML.Vision.Object.Detection.Model" Version="119.0.6" />
     <PackageReference Update="Xamarin.Firebase.Perf" Version="119.1.0" />
+    <PackageReference Update="Xamarin.Firebase.ProtoliteWellKnownTypes" Version="117.1.1" />
     <PackageReference Update="Xamarin.Firebase.Storage" Version="119.2.1" />
     <PackageReference Update="Xamarin.Firebase.Storage.Common" Version="117.0.0" />
-    <PackageReference Update="Xamarin.Firebase.ProtoliteWellKnownTypes" Version="117.1.1" />
-    <PackageReference Update="Xamarin.Google.Android.Play.Core" Version="1.9.1" />
+    <PackageReference Update="Xamarin.Google.Android.Play.Core" Version="01.9.1" />
     <PackageReference Update="Xamarin.Google.MLKit.Common" Version="117.1.1" />
     <PackageReference Update="Xamarin.Google.MLKit.BarcodeScanning" Version="116.1.0" />
     <PackageReference Update="Xamarin.Google.MLKit.DigitalInk.Recognition" Version="116.1.0" />
@@ -139,64 +142,54 @@
     <PackageReference Update="Xamarin.Google.MLKit.Translate" Version="116.1.1" />
     <PackageReference Update="Xamarin.Google.MLKit.Vision.Common" Version="116.3.0" />
     <PackageReference Update="Xamarin.Google.MLKit.Vision.Internal.Vkp" Version="118.0.0" />
-    <PackageReference Update="Xamarin.Google.Guava" Version="" />
-    <PackageReference Update="Xamarin.Google.Guava.ListenableFuture" Version="1.0.0.2" />
-    <PackageReference Update="Xamarin.AndroidX.Annotation" Version="1.1.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.Browser" Version="1.2.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.Collection" Version="1.1.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.Core" Version="1.2.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.Fragment" Version="1.1.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.Legacy.Support.Core.Utils" Version="1.0.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Extensions" Version="2.1.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.Loader" Version="1.1.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.MediaRouter" Version="1.1.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.Media" Version="1.1.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.1.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.LocalBroadcastManager" Version="1.0.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.ExifInterface" Version="1.0.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.2.0" />
-    <PackageReference Update="Xamarin.AndroidX.CardView" Version="1.0.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.ConstraintLayout" Version="1.1.3.1" />
-    <PackageReference Update="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.1" />
-    <PackageReference Update="Xamarin.AndroidX.Work.Runtime" Version="2.4.0" />
+
+    <!-- External dependencies ("dependencyOnly": true) -->
+
+    <PackageReference Update="Xamarin.GooglePlayServices.Measurement.Api" Version="71.1630.4" />
+    <PackageReference Update="Xamarin.GooglePlayServices.Measurement.Base" Version="71.1630.4" />
+    <PackageReference Update="Xamarin.Firebase.Analytics" Version="71.1630.4" />
+
     <PackageReference Update="Square.OkHttp" Version="2.7.5.1" />
-    <PackageReference Update="Xamarin.TensorFlow.Lite" Version="2.1.0.1" />
-    <PackageReference Update="Xamarin.Protobuf.Lite" Version="3.0.1" />
-    <PackageReference Update="Xamarin.Protobuf.JavaLite" Version="3.14.0" />
-    <PackageReference Update="Square.Retrofit" Version="1.9.0" />
+    <PackageReference Update="Square.OkHttp3" Version="4.8.1" />
+    <PackageReference Update="Square.Picasso" Version="2.71828.0" />
+    <PackageReference Update="Square.Retrofit" Version="1.9.0.1" />
+    <PackageReference Update="Xamarin.Android.Arch.Lifecycle.Common" Version="1.1.1.3" />
+    <PackageReference Update="Xamarin.Android.Arch.Lifecycle.Runtime" Version="1.1.1.3" />
+    <PackageReference Update="Xamarin.Android.ReactiveX.RxAndroid" Version="2.1.1" />
+    <PackageReference Update="Xamarin.Android.ReactiveX.RxJava" Version="2.2.9" />
+    <PackageReference Update="Xamarin.AndroidX.Annotation" Version="1.1.0.9" />
+    <PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.2.0.7" />
+    <PackageReference Update="Xamarin.AndroidX.Browser" Version="1.3.0.5" />
+    <PackageReference Update="Xamarin.AndroidX.CardView" Version="1.0.0.8" />
+    <PackageReference Update="Xamarin.AndroidX.Collection" Version="1.1.0.7" />
+    <PackageReference Update="Xamarin.AndroidX.ConstraintLayout" Version="2.0.4.2" />
+    <PackageReference Update="Xamarin.AndroidX.Core" Version="1.3.2.3" />
+    <PackageReference Update="Xamarin.AndroidX.ExifInterface" Version="1.3.2.2" />
+    <PackageReference Update="Xamarin.AndroidX.Fragment" Version="1.3.0.1" />
+    <PackageReference Update="Xamarin.AndroidX.Legacy.Support.Core.Utils" Version="1.0.0.7" />
+    <PackageReference Update="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />
+    <PackageReference Update="Xamarin.AndroidX.Lifecycle.Extensions" Version="2.2.0.7" />
+    <PackageReference Update="Xamarin.AndroidX.Loader" Version="1.1.0.7" />
+    <PackageReference Update="Xamarin.AndroidX.LocalBroadcastManager" Version="1.0.0.7" />
+    <PackageReference Update="Xamarin.AndroidX.Media" Version="1.2.1.2" />
+    <PackageReference Update="Xamarin.AndroidX.MediaRouter" Version="1.2.2.1" />
+    <PackageReference Update="Xamarin.AndroidX.RecyclerView" Version="1.1.0.8" />
+    <PackageReference Update="Xamarin.AndroidX.Work.Runtime" Version="2.5.0.1" />
+    <PackageReference Update="Xamarin.Chromium.CroNet.Api" Version="76.3809.111" />
+    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportApi" Version="2.2.1" />
+    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="2.3.3" />
+    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="2.2.5" />
+    <PackageReference Update="Xamarin.Google.AutoValue.Annotations" Version="1.6.6" />
+    <PackageReference Update="Xamarin.Google.Dagger" Version="2.27.0" />
+    <PackageReference Update="Xamarin.Google.Guava" Version="28.2.0" />
+    <PackageReference Update="Xamarin.Google.Guava.ListenableFuture" Version="1.0.0.2" />
+    <PackageReference Update="Xamarin.Grpc.Android" Version="1.28.0" />
+    <PackageReference Update="Xamarin.Grpc.OkHttp" Version="1.28.0" />
     <PackageReference Update="Xamarin.Grpc.Protobuf.Lite" Version="1.28.0" />
     <PackageReference Update="Xamarin.Grpc.Stub" Version="1.28.0" />
-    <PackageReference Update="Xamarin.Grpc.OkHttp" Version="1.28.0" />
-    <PackageReference Update="Xamarin.Grpc.Android" Version="1.28.0" />
-    <PackageReference Update="Xamarin.Google.AutoValue.Annotations" Version="1.6.6" />
-    <PackageReference Update="Square.OkHttp3" Version="3.12.3" />
-    <PackageReference Update="Square.OkHttp3" Version="4.3.1" />
-    <PackageReference Update="Xamarin.Google.Dagger" Version="2.27.0" />
-    <PackageReference Update="Xamarin.Android.Arch.Lifecycle.Common" Version="1.1.1.1" />
-    <PackageReference Update="Xamarin.Android.Arch.Lifecycle.Runtime" Version="1.1.1.1" />
-    <PackageReference Update="Xamarin.GooglePlayServices.Measurement.Base" Version="71.1630.1" />
-    <PackageReference Update="Xamarin.Chromium.CroNet.Api" Version="75.3770.101" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportApi" Version="2.2.1" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="2.2.4" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="2.3.1" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportApi" Version="2.2.0" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="2.2.5" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="2.2.1" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportApi" Version="2.2.0" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="2.2.2" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="2.2.2" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="2.2.3" />
-    <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="2.3.3" />
-    <PackageReference Update="Xamarin.Google.Dagger" Version="2.25.2" />
-    <PackageReference Update="Xamarin.Android.ReactiveX.RxAndroid" Version="2.1.1" />
-    <PackageReference Update="Xamarin.Android.ReactiveX.RxJava" Version="2.2.7" />
-    <PackageReference Update="Square.Picasso" Version="2.71828" />
-    <PackageReference Update="Xamarin.GooglePlayServices.Measurement.Api" Version="71.1630.1" />
-    <PackageReference Update="Xamarin.Firebase.Analytics" Version="71.1630.1" />
-    <PackageReference Update="Xamarin.GooglePlayServices.Vision.Common" Version="119.0.0-preview03" />
-    <PackageReference Update="Xamarin.GooglePlayServices.Vision" Version="119.0.0-preview03" />
-    <PackageReference Update="Xamarin.Firebase.Analytics" Version="71.1630.1" />
-    <PackageReference Update="Xamarin.Firebase.Iid" Version="119.0.1-preview03" />
     <PackageReference Update="Xamarin.JavaX.Inject" Version="1.0.0" />
+    <PackageReference Update="Xamarin.Protobuf.JavaLite" Version="3.14.0" />
+    <PackageReference Update="Xamarin.Protobuf.Lite" Version="3.0.1" />
+    <PackageReference Update="Xamarin.TensorFlow.Lite" Version="2.1.0.1" />
   </ItemGroup>
 </Project>

--- a/source/com.google.android.gms/play-services-basement/buildtasks.tests/Basement.BuildTasks.Tests.csproj
+++ b/source/com.google.android.gms/play-services-basement/buildtasks.tests/Basement.BuildTasks.Tests.csproj
@@ -51,9 +51,7 @@
     <Folder Include="Helpers\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit">
-      <Version>3.8.1</Version>
-    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.13.1" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/GooglePlayServices.Tests/GooglePlayServices.Tests.csproj
+++ b/tests/GooglePlayServices.Tests/GooglePlayServices.Tests.csproj
@@ -7,8 +7,8 @@
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <RootNamespace>GooglePlayServices.Tests</RootNamespace>
-    <AssemblyName>AndroidSupport.Tests</AssemblyName>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <AssemblyName>AndroidX.Tests</AssemblyName>
+    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <AndroidResgenClass>Resource</AndroidResgenClass>
@@ -66,11 +66,17 @@
     <Reference Include="Xamarin.Firebase.Crash">
       <HintPath>..\..\output\Xamarin.Firebase.Crash.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.Firebase.Database">
+      <HintPath>..\..\output\Xamarin.Firebase.Database.dll</HintPath>
+    </Reference>
     <Reference Include="Xamarin.Firebase.Database.Connection">
       <HintPath>..\..\output\Xamarin.Firebase.Database.Connection.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Firebase.Database">
-      <HintPath>..\..\output\Xamarin.Firebase.Database.dll</HintPath>
+    <Reference Include="Xamarin.Firebase.Dynamic.Links">
+      <HintPath>..\..\output\Xamarin.Firebase.Dynamic.Links.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Firebase.Firestore">
+      <HintPath>..\..\output\Xamarin.Firebase.Firestore.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Iid">
       <HintPath>..\..\output\Xamarin.Firebase.Iid.dll</HintPath>
@@ -78,11 +84,14 @@
     <Reference Include="Xamarin.Firebase.Messaging">
       <HintPath>..\..\output\Xamarin.Firebase.Messaging.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Firebase.Storage.Common">
-      <HintPath>..\..\output\Xamarin.Firebase.Storage.Common.dll</HintPath>
+    <Reference Include="Xamarin.Firebase.Perf">
+      <HintPath>..\..\output\Xamarin.Firebase.Perf.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.Firebase.Storage">
       <HintPath>..\..\output\Xamarin.Firebase.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Firebase.Storage.Common">
+      <HintPath>..\..\output\Xamarin.Firebase.Storage.Common.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Ads">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.Ads.dll</HintPath>
@@ -99,11 +108,14 @@
     <Reference Include="Xamarin.GooglePlayServices.AppInvite">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.AppInvite.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Auth.Base">
-      <HintPath>..\..\output\Xamarin.GooglePlayServices.Auth.Base.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Auth">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.Auth.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Auth.Api.Phone">
+      <HintPath>..\..\output\Xamarin.GooglePlayServices.Auth.Api.Phone.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Auth.Base">
+      <HintPath>..\..\output\Xamarin.GooglePlayServices.Auth.Base.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Awareness">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.Awareness.dll</HintPath>
@@ -122,6 +134,9 @@
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Drive">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.Drive.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Fido">
+      <HintPath>..\..\output\Xamarin.GooglePlayServices.Fido.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Fitness">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.Fitness.dll</HintPath>
@@ -153,6 +168,9 @@
     <Reference Include="Xamarin.GooglePlayServices.Nearby">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.Nearby.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Oss.Licenses">
+      <HintPath>..\..\output\Xamarin.GooglePlayServices.Oss.Licenses.dll</HintPath>
+    </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Panorama">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.Panorama.dll</HintPath>
     </Reference>
@@ -165,11 +183,11 @@
     <Reference Include="Xamarin.GooglePlayServices.SafetyNet">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.SafetyNet.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.TagManager.Api">
-      <HintPath>..\..\output\Xamarin.GooglePlayServices.TagManager.Api.dll</HintPath>
-    </Reference>
     <Reference Include="Xamarin.GooglePlayServices.TagManager">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.TagManager.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.TagManager.Api">
+      <HintPath>..\..\output\Xamarin.GooglePlayServices.TagManager.Api.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.TagManager.V4.Impl">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.TagManager.V4.Impl.dll</HintPath>
@@ -180,44 +198,27 @@
     <Reference Include="Xamarin.GooglePlayServices.Vision">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.Vision.dll</HintPath>
     </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Vision.Common">
+      <HintPath>..\..\output\Xamarin.GooglePlayServices.Vision.Common.dll</HintPath>
+    </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Wallet">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.Wallet.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Wearable">
       <HintPath>..\..\output\Xamarin.GooglePlayServices.Wearable.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Firebase.Firestore">
-      <HintPath>..\..\output\Xamarin.Firebase.Firestore.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Auth.Api.Phone">
-      <HintPath>..\..\output\Xamarin.GooglePlayServices.Auth.Api.Phone.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Fido">
-      <HintPath>..\..\output\Xamarin.GooglePlayServices.Fido.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Oss.Licenses">
-      <HintPath>..\..\output\Xamarin.GooglePlayServices.Oss.Licenses.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.GooglePlayServices.Vision.Common">
-      <HintPath>..\..\output\Xamarin.GooglePlayServices.Vision.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Firebase.Dynamic.Links">
-      <HintPath>..\..\output\Xamarin.Firebase.Dynamic.Links.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Firebase.Perf">
-      <HintPath>..\..\output\Xamarin.Firebase.Perf.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Android.Support.v4" Version="27.0.2.1" />
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2.1" />
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="27.0.2.1" />
-    <PackageReference Include="Xamarin.Build.Download" Version="0.4.11" />
-    <PackageReference Include="xunit.core" Version="2.3.1" />
-    <PackageReference Include="xunit.abstractions" Version="2.0.1" />
-    <PackageReference Include="xunit.assert" Version="2.3.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.utility" Version="2.3.1" />
+    <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.2.0.7" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />
+    <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.2.1" />
+    <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.8" />
+    <PackageReference Include="Xamarin.Build.Download" Version="0.10.0" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
+    <PackageReference Include="xunit.core" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
@@ -243,5 +244,5 @@
     <Folder Include="Resources\drawable\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\..\generated.targets" />
+  <Import Project="..\..\generated\generated.targets" />
 </Project>

--- a/tests/GooglePlayServices.Tests/MainActivity.cs
+++ b/tests/GooglePlayServices.Tests/MainActivity.cs
@@ -1,18 +1,20 @@
 ﻿using Android.App;
-using Android.Widget;
 using Android.OS;
+using Android.Views;
+using Android.Widget;
+
+using AndroidX.AppCompat.App;
+
+using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Xunit;
-using System;
-using Xunit.Runners;
 using System.Threading.Tasks;
-using Android.Support.V7.App;
-using Android.Views;
+
+using Xunit.Runners;
 
 namespace GooglePlayServices.Tests
 {
-	[Activity(Label = "AndroidSupport.Tests", MainLauncher = true, Theme="@style/Theme.AppCompat.Light", Icon = "@mipmap/icon")]
+	[Activity(Label = "AndroidX.Tests", MainLauncher = true, Theme="@style/Theme.AppCompat.Light", Icon = "@mipmap/icon")]
 	public class MainActivity : AppCompatActivity
 	{
 		public static Activity TestParentActivity { get; set; }

--- a/tests/GooglePlayServices.Tests/Properties/AssemblyInfo.cs
+++ b/tests/GooglePlayServices.Tests/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using Android.App;
 // Information about this assembly is defined by the following attributes. 
 // Change them to the values specific to your project.
 
-[assembly: AssemblyTitle("AndroidSupport.Tests")]
+[assembly: AssemblyTitle("AndroidX.Tests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]

--- a/tests/GooglePlayServices.Tests/Resources/values/Strings.xml
+++ b/tests/GooglePlayServices.Tests/Resources/values/Strings.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<string name="hello">Hello World, Click Me!</string>
-	<string name="app_name">AndroidSupport.Tests</string>
+	<string name="app_name">AndroidX.Tests</string>
 </resources>


### PR DESCRIPTION
This PR is part 2 of #437. It cleans up dependencies in main source directory.

***
Dependencies
---
Artifacts built as part of this repository (`"dependencyOnly": false`) are left intact (except for `protolite-well-known-types` which was misplaced unintentionally I guess).

External dependencies (`"dependencyOnly": true`) were really messed up. So I sorted they by `nugetId`, bumped up their versions, and deleted unnecessary duplicates.

***
Related changes
---
1. Relative path to `generated.targets` was incorrect in `GooglePlayServices.Tests.csproj`.
2. Additionally I migrated `GooglePlayServices.Tests.csproj` to AndroidX.
