### PR TITLE
artifact version from nuget version in tags fixes and improvements

### DIFF
--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -48,8 +48,23 @@
 
       string c = Model.Name;
 
-      int index = Model.NuGetVersion.LastIndexOf(".");
-      string artifact_version = Model.NuGetVersion.Substring(1, index + 2); // skip "1" in "1<major>.<minor>.<patch>"
+      string[] artifact_version_parts = Model.NuGetVersion
+                                              .Substring(1, Model.NuGetVersion.Length - 1)
+                                              .Split(new string[] { "-" }, StringSplitOptions.None);
+      string artifact_version = null;
+
+      string artifact_version_release = artifact_version_parts[0];
+      string[] artifact_version_release_parts = artifact_version_release.Split(new string[] { "." }, StringSplitOptions.None);
+      artifact_version = string.Join(".", artifact_version_release_parts, 0, 3);
+
+      if (artifact_version_parts.Length == 1)
+      {
+          // release
+      }
+      if (artifact_version_parts.Length == 2)
+      {
+          artifact_version += "-" + artifact_version_parts[1];
+      }
   }
 
   <PropertyGroup>

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -1,3 +1,4 @@
+@using System
 @using System.Linq
 @using System.Collections.Generic
 
@@ -121,13 +122,13 @@
       Ignoreable
       Performance hit for builds
       - BG8A04: <attr path="XPath" /> matched no nodes.
-      - BG8A00: <remove-node path="XPath" /> matched no nodes.  
+      - BG8A00: <remove-node path="XPath" /> matched no nodes.
     -->
     <NoWarn>BG8A04;BG8A00</NoWarn>
 
     <!--
-      Harmfull 
-      - BG8401: Skipping managed_type, due to a duplicate field, method or nested type name. (Nested type) (Java type: java_type)  
+      Harmfull
+      - BG8401: Skipping managed_type, due to a duplicate field, method or nested type name. (Nested type) (Java type: java_type)
       - BG8604: top ancestor Type1 not found for nested type Namespace.Type1.Type2
       - BG8C00: For type Namespace.Type1, base interface java.Interface does not exist
       - BG8700: Unknown return type java.Type1 in method Method1 in managed type Namespace.Type2.
@@ -142,7 +143,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      @foreach (var art in @Model.MavenArtifacts) 
+      @foreach (var art in @Model.MavenArtifacts)
       {
       <TransformFile Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-paramnames.xml" Condition="Exists('..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-paramnames.xml')" />
       }
@@ -153,17 +154,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    @foreach (var art in @Model.MavenArtifacts) 
+    @foreach (var art in @Model.MavenArtifacts)
     {
-    <JavaSourceJar 
-          Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-sources.jar" 
-          Condition="Exists('..\..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-sources.jar')" 
+    <JavaSourceJar
+          Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-sources.jar"
+          Condition="Exists('..\..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-sources.jar')"
           />
-    <JavaDocJar 
-          Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-javadoc.jar" 
-          Condition="Exists('..\..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-javadoc.jar')" 
+    <JavaDocJar
+          Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-javadoc.jar"
+          Condition="Exists('..\..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-javadoc.jar')"
           />
-    }   
+    }
   </ItemGroup>
 
   <ItemGroup>
@@ -230,13 +231,13 @@
       if (art.MavenArtifactPackaging == "aar") {
         if ((System.Environment.GetEnvironmentVariable("LOCAL_TEST_PKG") ?? "") == "true") {
     <LibraryProjectZip Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).aar" />
-    
+
         } else {
     <InputJar Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)\classes.jar" />
     <!-- For those artifacts with lib/ folder -->
     <InputJar
       Condition="Exists('..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)\libs\')"
-      Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)\libs\*.jar" 
+      Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)\libs\*.jar"
       />
         }
       } else {
@@ -264,7 +265,7 @@
     @foreach (var dep in @Model.NuGetDependencies) {
       if (!dep.IsProjectReference) {
       <PackageReference Include="@(dep.NuGetPackageId)" Version="@(dep.NuGetVersion)" PrivateAssets="none" />
-      }      
+      }
     }
     @if (@Model.NuGetPackageId == "Xamarin.GooglePlayServices.SafetyNet")
     {
@@ -285,10 +286,10 @@
 
   @*
   <!--
-  NOTE: 
-  Xamarin.Build.Download version set in GooglePlaySericesProjects.cshtml template is 
+  NOTE:
+  Xamarin.Build.Download version set in GooglePlaySericesProjects.cshtml template is
   important for attributes in GooglePlaySericesTargets.cshtml template
-  
+
   XamarinBuildDownloadAndroidAarLibrary   v >=  0.10.0
   XamarinBuildDownloadRestoreAssemblyAar  v <   0.10.0
   -->
@@ -414,7 +415,7 @@
           IconUrl = "https://raw.githubusercontent.com/xamarin/GooglePlayServicesComponents/master/icons/play-services-analytics-impl_128x128.png",
         }
       },
-      /* 
+      /*
         {
         "Xamarin.GooglePlayServices.AppIndexing",
         new  NugetPackageCustomMetaData()

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -49,7 +49,7 @@
       string c = Model.Name;
 
       int index = Model.NuGetVersion.LastIndexOf(".");
-      string artifact_version = Model.NuGetVersion.Substring(1, index); // skip "1" in "1<major>.<minor>.<patch>"
+      string artifact_version = Model.NuGetVersion.Substring(1, index + 2); // skip "1" in "1<major>.<minor>.<patch>"
   }
 
   <PropertyGroup>

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -49,7 +49,7 @@
       string c = Model.Name;
 
       int index = Model.NuGetVersion.LastIndexOf(".");
-      string artifact_version = Model.NuGetVersion.Substring(0, index);
+      string artifact_version = Model.NuGetVersion.Substring(1, index); // skip "1" in "1<major>.<minor>.<patch>"
   }
 
   <PropertyGroup>


### PR DESCRIPTION
* removing prefix "1" from nuget version to obtain artifact version in tags

  current binderator API does not expose Android artifact version, so it must be calculated from NuGet version

* fixing "patch" part of the version

  Previous version did not take into account possible prerelase suffix, so parsing did cut off patch part (instead of 120.0.0 it would be 120.0)


sample for both cases:

```
artifact=androidx.core:core artifact_versioned=androidx.core:core:1.5
```

https://www.nuget.org/packages/Xamarin.AndroidX.Core/

