### PR TITLE
[yaml] Update to XA 16.10.

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -33,13 +33,13 @@ jobs:
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-9-macos
+            boots https://aka.ms/xamarin-android-commercial-d16-10-macos
           condition: eq(variables['System.JobName'], 'macos')
         - pwsh: |
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-9-windows
+            boots https://aka.ms/xamarin-android-commercial-d16-10-windows
           condition: eq(variables['System.JobName'], 'windows')
       tools:
         - 'xamarin.androidbinderator.tool': '0.4.3'

--- a/config.json
+++ b/config.json
@@ -140,7 +140,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-basement",
         "version": "17.6.0",
-        "nugetVersion": "117.6.0",
+        "nugetVersion": "117.6.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Basement",
         "dependencyOnly": false
       },
@@ -180,7 +180,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-cronet",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0",
+        "nugetVersion": "117.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.CroNet",
         "dependencyOnly": false
       },
@@ -188,7 +188,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-drive",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0",
+        "nugetVersion": "117.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Drive",
         "dependencyOnly": false
       },
@@ -244,7 +244,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-identity",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0",
+        "nugetVersion": "117.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Identity",
         "dependencyOnly": false
       },
@@ -412,7 +412,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-plus",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0",
+        "nugetVersion": "117.0.0.1",
         "nugetId": "Xamarin.GooglePlayServices.Plus",
         "dependencyOnly": false
       },
@@ -508,7 +508,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-wallet",
         "version": "18.1.3",
-        "nugetVersion": "118.1.3",
+        "nugetVersion": "118.1.3.1",
         "nugetId": "Xamarin.GooglePlayServices.Wallet",
         "dependencyOnly": false
       },
@@ -580,7 +580,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appindexing",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0",
+        "nugetVersion": "120.0.0.1",
         "nugetId": "Xamarin.Firebase.AppIndexing",
         "dependencyOnly": false
       },
@@ -588,7 +588,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-auth",
         "version": "21.0.1",
-        "nugetVersion": "121.0.1",
+        "nugetVersion": "121.0.1.1",
         "nugetId": "Xamarin.Firebase.Auth",
         "dependencyOnly": false
       },
@@ -716,7 +716,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-firestore",
         "version": "23.0.1",
-        "nugetVersion": "123.0.1",
+        "nugetVersion": "123.0.1.1",
         "nugetId": "Xamarin.Firebase.Firestore",
         "dependencyOnly": false
       },
@@ -796,7 +796,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-measurement-connector-impl",
         "version": "17.0.5",
-        "nugetVersion": "117.0.5",
+        "nugetVersion": "117.0.5.1",
         "nugetId": "Xamarin.Firebase.Measurement.Connector.Impl",
         "dependencyOnly": false
       },
@@ -1012,7 +1012,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-automl",
         "version": "16.2.1",
-        "nugetVersion": "116.2.1",
+        "nugetVersion": "116.2.1.1",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.AutoML",
         "dependencyOnly": false
       },
@@ -1020,7 +1020,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-common",
         "version": "17.0.0",
-        "nugetVersion": "117.0.0",
+        "nugetVersion": "117.0.0.1",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Common",
         "dependencyOnly": false
       },
@@ -1036,7 +1036,7 @@
         "groupId": "com.google.mlkit",
         "artifactId": "image-labeling-default-common",
         "version": "16.0.0",
-        "nugetVersion": "116.0.0",
+        "nugetVersion": "116.0.0.1",
         "nugetId": "Xamarin.Google.MLKit.ImageLabeling.Default.Common",
         "dependencyOnly": false
       },


### PR DESCRIPTION
Currently our CI seems to be producing **different** builds between Windows & Mac:

16.9 - Windows:
![image](https://user-images.githubusercontent.com/179295/124023516-a412c900-d9b3-11eb-8378-f15f0e34d806.png)

16.9 - Mac:
![image](https://user-images.githubusercontent.com/179295/124023448-90676280-d9b3-11eb-834b-9ef86935f688.png)

This comparison works against the versions on NuGet.org, so I guess we publish the packages created on Mac to NuGet, which shows fewer differences.

Unrelated, we should update to the latest XA: 16.10.  Using this version, both Windows & Mac show the same diffs as Windows XA 16.9.  It would seem like the Mac XA 16.9 package was not as recent as the Windows one.

16.10 - Mac
![image](https://user-images.githubusercontent.com/179295/124062684-beba6180-d9f6-11eb-93c1-11c728c687da.png)

Additionally, let's bump the patch version of the NuGets with diffs, so updated versions will get pushed to NuGet.org, reducing noise on future diffs.