### PR TITLE
Change Play.Core binding transforms to fix inconsistency with native library

### DIFF
--- a/source/com.google.android.play/core/Transforms/Metadata.xml
+++ b/source/com.google.android.play/core/Transforms/Metadata.xml
@@ -2,8 +2,15 @@
 <metadata>
 
     <remove-node
-        path="/api/package[@name='com.google.android.play.core.tasks']/class[@name='Task']/typeParameters"
+        path="/api/package[@name='com.google.android.play.core.tasks']/class[@name='NativeOnCompleteListener']"
         />
+
+    <attr
+        path="/api/package[@name='com.google.android.play.core.tasks']/class[@name='Tasks']"
+        name="managedName"
+        >
+        Tasks
+    </attr>
 
     <attr
         path="/api/package[@name='com.google.android.play.core.assetpacks']/class[@name='NativeAssetPackStateUpdateListener']/method[@name='onStateUpdate' and count(parameter)=1 and parameter[1][@type='com.google.android.play.core.assetpacks.AssetPackState']]/parameter[1]"


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):
Android Play Core 1.10.0

### Does this change any of the generated binding API's?
Yes

### Describe your contribution
More details in issue #483
