### PR TITLE
Convert to Xamarin.Legacy.Sdk.

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -8,6 +8,11 @@ pr:
   - master_based_androidx*
   
 variables:
+  AndroidBinderatorVersion: 0.4.7
+  AndroidXMigrationVersion: 1.0.8
+  DotNetVersion: 6.0.100-preview.6.21355.2
+  LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d16-10-macos
+  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d16-10-windows
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
 #   XAMARIN_ANDROID_PATH: <path to Xamarin.Android>
@@ -28,18 +33,25 @@ jobs:
     parameters:
       timeoutInMinutes: 240
       areaPath: 'DevDiv\Xamarin SDK\Android'
+      initSteps:
+        - task: UseDotNet@2
+          displayName: install .NET $(DotNetVersion)
+          inputs:
+            version: $(DotNetVersion)
+        - pwsh: |
+            dotnet workload install microsoft-android-sdk-full
       preBuildSteps:
         - pwsh: |
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-10-macos
+            boots $(LegacyXamarinAndroidPkg)
           condition: eq(variables['System.JobName'], 'macos')
         - pwsh: |
             dotnet tool uninstall --global Cake.Tool
             dotnet tool install --global Cake.Tool
             dotnet tool install --global boots
-            boots https://aka.ms/xamarin-android-commercial-d16-10-windows
+            boots $(LegacyXamarinAndroidVsix)
           condition: eq(variables['System.JobName'], 'windows')
       tools:
         - 'xamarin.androidbinderator.tool': '0.4.3'

--- a/global.json
+++ b/global.json
@@ -3,6 +3,7 @@
     {
         "MSBuild.Sdk.Extras": "3.0.23",
         "Microsoft.Build.Traversal": "2.1.1",
-        "Microsoft.Build.NoTargets": "2.0.1"
+        "Microsoft.Build.NoTargets": "2.0.1",
+        "Xamarin.Legacy.Sdk": "0.1.0-alpha2"
     }
 }

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -6,7 +6,7 @@
   var targetFrameworkMoniker = "MonoAndroid90";
 }
 
-<Project Sdk="MSBuild.Sdk.Extras">
+<Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
     <TargetFramework>@(targetFrameworkMoniker)</TargetFramework>
     <IsBindingProject>true</IsBindingProject>
@@ -15,17 +15,6 @@
     } else {
     <AssemblyName>@(Model.NuGetPackageId)</AssemblyName>
     }
-    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
-    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
-    <EnableProguard>true</EnableProguard>
-    <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
-    <AndroidUseAapt2>true</AndroidUseAapt2>
-    <AndroidDexTool>d8</AndroidDexTool>
-    <AndroidLinkTool>r8</AndroidLinkTool>
-    <AndroidManifestMerger>manifestmerger.jar</AndroidManifestMerger>
   </PropertyGroup>
 
   @{
@@ -269,6 +258,7 @@
     }
     @if (@Model.NuGetPackageId == "Xamarin.GooglePlayServices.SafetyNet")
     {
+      <Reference Include="System.Net.Http" />
       <PackageReference Include="System.Text.Json" Version="5.0.2" />
     }
     @if (@Model.NuGetPackageId == "Xamarin.Firebase.Firestore")


### PR DESCRIPTION
Context: https://github.com/xamarin/GooglePlayServicesComponents/pull/418

The first step in multi-targeting GPS/FB/MLKit with `net6` is to migrate to `Xamarin.Legacy.Sdk`, which runs on top of .NET 6 but can build `MonoAndroid9.0`.  We'll commit this first to help make it easier to run our diff logic on the resulting packages to make sure there are no regressions.  A future commit will then enable `net6`.

Changes made:
- CI - Install .NET 6 Preview 5
- CI - Install the Android workload
- Change Cake to use `DotNetCore` versions
- Update `Sdk` to `Xamarin.Legacy.Sdk`