### PR TITLE
[build] Bump to .NET 6 - Preview 7.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <!-- Opt out of C#8 features to maintain compatibility with legacy -->
+    <AndroidBoundInterfacesContainConstants>false</AndroidBoundInterfacesContainConstants>
+    <AndroidBoundInterfacesContainTypes>false</AndroidBoundInterfacesContainTypes>
+    <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>false</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
+  </PropertyGroup>
+</Project>

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -10,7 +10,7 @@ pr:
 variables:
   AndroidBinderatorVersion: 0.4.7
   AndroidXMigrationVersion: 1.0.8
-  DotNetVersion: 6.0.100-preview.6.21355.2
+  DotNetVersion: 6.0.100-preview.7.21379.14
   LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d16-10-macos
   LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d16-10-windows
   BUILD_NUMBER: $(Build.BuildNumber)
@@ -39,7 +39,7 @@ jobs:
           inputs:
             version: $(DotNetVersion)
         - pwsh: |
-            dotnet workload install microsoft-android-sdk-full
+            dotnet workload install android
       preBuildSteps:
         - pwsh: |
             dotnet tool uninstall --global Cake.Tool


### PR DESCRIPTION
The release of .NET 6 P7 broke our use of `dotnet workload install microsoft-android-sdk-full` for P6, which is causing our CI setup to fail:

```
Welcome to .NET 6.0!
---------------------
SDK Version: 6.0.100-preview.6.21355.2

Installing workload manifest microsoft.net.sdk.android version 30.0.100-preview.7.110.
Installing workload manifest microsoft.net.sdk.ios version 15.0.100-preview.7231.
Installing workload manifest microsoft.net.sdk.maccatalyst version 15.0.100-preview.7231.
Installing workload manifest microsoft.net.sdk.macos version 12.0.100-preview.7231.
Installing workload manifest microsoft.net.sdk.maui version 6.0.100-preview.7.1345.
Installing workload manifest microsoft.net.sdk.tvos version 15.0.100-preview.7231.
Installing workload manifest microsoft.net.workload.mono.toolchain version 6.0.0-preview.7.21377.19.
Workload installation failed, rolling back installed packs...
Installing workload manifest microsoft.net.sdk.android version 30.0.100-preview.6.53.
Workload installation failed: Inconsistency in workload manifest 'microsoft.net.workload.mono.toolchain': missing dependency 'Microsoft.NET.Workload.Emscripten'
Installation roll back failed: Failed to install manifest microsoft.net.sdk.android version 30.0.100-preview.6.53: microsoft.net.sdk.android.manifest-6.0.100::30.0.100-preview.6.53 is not found in NuGet feeds https://api.nuget.org/v3/index.json;C:\Program Files (x86)\Microsoft SDKs\NuGetPackages\"..
```

To fix this we upgraded to Preview 7.  Additional changes were need to maintain compatibility with our Legacy packages because P7 [changes the defaults](https://github.com/xamarin/xamarin-android/blob/main/Documentation/guides/OneDotNetBindingProjects.md#migration-considerations) for Android bindings libraries regarding usage of C#8 features.