### PR TITLE
Release Xamarin.Firebase.AppIndexing with net6.0-android for AndroidX dependency.

### DIFF
--- a/config.json
+++ b/config.json
@@ -581,7 +581,7 @@
         "groupId": "com.google.firebase",
         "artifactId": "firebase-appindexing",
         "version": "20.0.0",
-        "nugetVersion": "120.0.0.1",
+        "nugetVersion": "120.0.0.2",
         "nugetId": "Xamarin.Firebase.AppIndexing",
         "dependencyOnly": false
       },


### PR DESCRIPTION
`Xamarin.Firebase.AppIndexing` is a circular dependency with AndroidX.  We need this package to be `net6.0-android` in order to build AndroidX.  Then we'll need it updated again to use `net6.0-android` versions of AndroidX.