### PR TITLE
Bump to xamarin/xamarin-android/release/6.0.1xx-preview10@27295e27

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -10,7 +10,9 @@ pr:
 variables:
   AndroidBinderatorVersion: 0.5.1
   AndroidXMigrationVersion: 1.0.8
-  DotNetVersion: 6.0.100-rc.1.21463.6
+  DotNetVersion: 6.0.100-rc.2.21505.57
+  DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
+  NuGetOrgSource: https://api.nuget.org/v3/index.json
   LegacyXamarinAndroidPkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
   LegacyXamarinAndroidVsix: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix
   BUILD_NUMBER: $(Build.BuildNumber)
@@ -41,7 +43,8 @@ jobs:
           inputs:
             version: $(DotNetVersion)
         - pwsh: |
-            dotnet workload install android
+            dotnet workload update --verbosity diag --from-rollback-file workload.json --source $(Dotnet6Source) --source $(NuGetOrgSource)
+            dotnet workload install android --verbosity diag --skip-manifest-update --source $(Dotnet6Source) --source $(NuGetOrgSource)
         - task: JavaToolInstaller@0
           inputs:
             versionSpec: '11'

--- a/workload.json
+++ b/workload.json
@@ -1,0 +1,10 @@
+{
+    "microsoft.net.sdk.android": "31.0.101-preview.10.59",
+    "microsoft.net.sdk.ios": "15.0.101-preview.9.31",
+    "microsoft.net.sdk.maccatalyst": "15.0.101-preview.9.31",
+    "microsoft.net.sdk.macos": "12.0.101-preview.9.31",
+    "microsoft.net.sdk.maui": "6.0.101-preview.9.1843",
+    "microsoft.net.sdk.tvos": "15.0.101-preview.9.31",
+    "microsoft.net.workload.emscripten": "6.0.0-rc.2.21474.1",
+    "microsoft.net.workload.mono.toolchain": "6.0.0-rc.2.21480.5"
+}


### PR DESCRIPTION
Copied from: https://github.com/xamarin/AndroidX/pull/413
Context: https://github.com/xamarin/xamarin-android/commits/release/6.0.1xx-preview10
Context: https://github.com/dotnet/maui/wiki/Installing-.NET-6

We need to build with a version of the .NET 6 `android` workload that
contains the fix:

https://github.com/xamarin/java.interop/commit/2d5431f765928e5377288d3284ace3c5d871755a

For .NET 6, we should:

1. Install the latest public .NET 6 RC 2 release.
2. Use a `workload.json` file to pin to a specific build of the
   `android` workload.
3. Use the `dotnet6` feed when installing the workload.

I used the `workload.json` file currently reported by running:

    dotnet workload update --print-rollback

I adjusted the version number to match the appropriate build of:

    "microsoft.net.sdk.android": "31.0.101-preview.10.56",