### PR TITLE
[play-services-auth-base] Mark needed type as not obfuscated.

### DIFF
--- a/config.json
+++ b/config.json
@@ -162,7 +162,7 @@
         "groupId": "com.google.android.gms",
         "artifactId": "play-services-auth-base",
         "version": "17.1.4",
-        "nugetVersion": "117.1.4.2",
+        "nugetVersion": "117.1.4.3",
         "nugetId": "Xamarin.GooglePlayServices.Auth.Base",
         "dependencyOnly": false
       },

--- a/source/com.google.android.gms/play-services-auth-base/Transforms/Metadata.xml
+++ b/source/com.google.android.gms/play-services-auth-base/Transforms/Metadata.xml
@@ -11,7 +11,7 @@
     
 
 	<!-- Remove *zz* obfuscated items -->
-	<remove-node path="/api/package/class[contains(@name, 'zz') and @name != 'zzd' and @name != 'zze' and @name != 'zzg']" />
+	<remove-node path="/api/package/class[contains(@name, 'zz') and @name != 'zzd' and @name != 'zze' and @name != 'zzg' and @name != 'zzl']" />
 	<remove-node path="/api/package/interface[contains(@name, 'zz')]" />
 	<remove-node path="/api/*/*/method[contains(@name, 'zz')]" />
 	<remove-node path="/api/*/*/field[contains(@name, 'zz')]" />
@@ -25,6 +25,7 @@
 
 	<attr path="/api/package[@name='com.google.android.gms.auth']/class[@name='zzd']" name="obfuscated">false</attr>
     <attr path="/api/package[@name='com.google.android.gms.auth']/class[@name='zzg']" name="obfuscated">false</attr>
+	<attr path="/api/package[@name='com.google.android.gms.auth']/class[@name='zzl']" name="obfuscated">false</attr>
 
     <!--	<attr path="/api/package[@name='com.google.android.gms.auth']/class[@name='GoogleAuthUtil']" name="extends">Java.Lang.Object</attr>-->
 


### PR DESCRIPTION
Fixes #532.

In `play-services-auth-base-17.1.3` the base class for `com.google.android.gms.auth.GoogleAuthUtil` was changed:

17.1.2:
```java
public final class GoogleAuthUtil extends zzg { ... }
```

17.1.3:
```java
public final class GoogleAuthUtil extends zzl { ... }
```

We do not normally bind `zzl` because it is an obfuscated type, however if we don't the `GoogleAuthUtil` class does not get bound since the base type is missing.

Add metadata to bind `zzl`, which results in `GoogleAuthUtil` being bound.