### PR TITLE
Update Xamarin.Android to d17.0 and VS2022.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,5 +10,8 @@
     
     <!-- .NET 6+ packages support back to API-21 -->
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
+    
+    <!-- Hold off on JavaTypeSystem until d17-1 for needed bugfixes -->
+    <_AndroidUseJavaLegacyResolver>true</_AndroidUseJavaLegacyResolver>
   </PropertyGroup>
 </Project>

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -13,8 +13,8 @@ variables:
   DotNetVersion: 6.0.100
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
-  LegacyXamarinAndroidPkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4941337/d16-11/7776c9f1c8fac303c3aa57867825990850be0384/xamarin.android-11.4.0.5.pkg
-  LegacyXamarinAndroidVsix: https://download.visualstudio.microsoft.com/download/pr/7372b89a-b719-426c-9916-c33cbc6c7a61/45c38957fdcacfbee95be95ee40c4f5a4cc9ace69416625ad26e2da83b176941/Xamarin.Android.Sdk-11.4.0.5.vsix
+  LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d17-0-macos
+  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-0-windows
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
 #   XAMARIN_ANDROID_PATH: <path to Xamarin.Android>
@@ -35,8 +35,8 @@ jobs:
     parameters:
       timeoutInMinutes: 240
       areaPath: 'DevDiv\Xamarin SDK\Android'
-      macosImage: 'macOS-11'                                  # the name of the macOS VM image
-                                                              # BigSur 20211120
+      macosImage: 'macOS-11'                                  # the name of the macOS VM image (BigSur)
+      windowsAgentPoolName: android-win-2022
       xcode: 13.1
       dotnet: '5.0.403'                                       # the version of .NET Core to use
       dotnetStable: '3.1.415'                                 # the stable version of .NET Core to use
@@ -45,7 +45,6 @@ jobs:
         - Xamarin
         - GoogleGson
         - Square
-      windowsAgentPoolName: android-win-2019
       initSteps:
         - task: UseDotNet@2
           displayName: install .NET $(DotNetVersion)

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
         "MSBuild.Sdk.Extras": "3.0.23",
         "Microsoft.Build.Traversal": "2.1.1",
         "Microsoft.Build.NoTargets": "2.0.1",
-        "Xamarin.Legacy.Sdk": "0.1.0-alpha2"
+        "Xamarin.Legacy.Sdk": "0.1.2-alpha6"
     }
 }

--- a/samples/com.google.android.gms/play-services-ads-lite/AdsLiteSample.UITests/AdsLiteSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-ads-lite/AdsLiteSample.UITests/AdsLiteSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AdsLiteSample.UITests</RootNamespace>
     <AssemblyName>AdsLiteSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-ads/AdMobSample.UITests/AdMobSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-ads/AdMobSample.UITests/AdMobSample.UITests.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AdMobSample.UITests</RootNamespace>
     <AssemblyName>AdMobSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-analytics/AnalyticsSample.UITests/AnalyticsSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-analytics/AnalyticsSample.UITests/AnalyticsSample.UITests.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AnalyticsSample.UITests</RootNamespace>
     <AssemblyName>AnalyticsSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-appinvite/AppInviteSample.UITests/AppInviteSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-appinvite/AppInviteSample.UITests/AppInviteSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AppInviteSample.UITests</RootNamespace>
     <AssemblyName>AppInviteSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-cast/CastingCall.UITests/CastingCall.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-cast/CastingCall.UITests/CastingCall.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>CastingCall.UITests</RootNamespace>
     <AssemblyName>CastingCall.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-drive/DriveSample.UITests/DriveSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-drive/DriveSample.UITests/DriveSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>DriveSample.UITests</RootNamespace>
     <AssemblyName>DriveSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-fitness/BasicSensorsApi.UITests/BasicSensorsApi.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-fitness/BasicSensorsApi.UITests/BasicSensorsApi.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>BasicSensorsApi.UITests</RootNamespace>
     <AssemblyName>BasicSensorsApi.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-games/BeGenerous.UITests/BeGenerous.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-games/BeGenerous.UITests/BeGenerous.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>BeGenerous.UITests</RootNamespace>
     <AssemblyName>BeGenerous.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-gcm/GCMSample.UITests/GCMSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-gcm/GCMSample.UITests/GCMSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>GCMSample.UITests</RootNamespace>
     <AssemblyName>GCMSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-location/LocationSample.UITests/LocationSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-location/LocationSample.UITests/LocationSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>LocationSample.UITests</RootNamespace>
     <AssemblyName>LocationSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-maps/MapsSample.UITests/MapsSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-maps/MapsSample.UITests/MapsSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>MapsSample.UITests</RootNamespace>
     <AssemblyName>MapsSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-nearby/NearbySample.UITests/NearbySample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-nearby/NearbySample.UITests/NearbySample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>NearbySample.UITests</RootNamespace>
     <AssemblyName>NearbySample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-panorama/PanoramaSample.UITests/PanoramaSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-panorama/PanoramaSample.UITests/PanoramaSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PanoramaSample.UITests</RootNamespace>
     <AssemblyName>PanoramaSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-places/PlacesAsync.UITests/PlacesAsync.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-places/PlacesAsync.UITests/PlacesAsync.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PlacesAsync.UITests</RootNamespace>
     <AssemblyName>PlacesAsync.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-plus/PlusSample.UITests/PlusSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-plus/PlusSample.UITests/PlusSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>PlusSample.UITests</RootNamespace>
     <AssemblyName>PlusSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-safetynet/SafetyNetSample.UITests/SafetyNetSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-safetynet/SafetyNetSample.UITests/SafetyNetSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>SafetyNetSample.UITests</RootNamespace>
     <AssemblyName>SafetyNetSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-vision/VisionSample.UITests/VisionSample.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-vision/VisionSample.UITests/VisionSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>VisionSample.UITests</RootNamespace>
     <AssemblyName>VisionSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.gms/play-services-wallet/AndroidPayQuickstart.UITests/AndroidPayQuickstart.UITests.csproj
+++ b/samples/com.google.android.gms/play-services-wallet/AndroidPayQuickstart.UITests/AndroidPayQuickstart.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AndroidPayQuickstart.UITests</RootNamespace>
     <AssemblyName>AndroidPayQuickstart.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.android.play/play-services-assetpack/AssetPackSample.UITests/AssetPackSample.UITests.csproj
+++ b/samples/com.google.android.play/play-services-assetpack/AssetPackSample.UITests/AssetPackSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AssetPackSample.UITests</RootNamespace>
     <AssemblyName>AssetPackSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.firebase/firebase-ads/FirebaseAdmobQuickstart.UITests/FirebaseAdmobQuickstart.UITests.csproj
+++ b/samples/com.google.firebase/firebase-ads/FirebaseAdmobQuickstart.UITests/FirebaseAdmobQuickstart.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FirebaseAdmobQuickstart.UITests</RootNamespace>
     <AssemblyName>FirebaseAdmobQuickstart.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.firebase/firebase-analytics/FirebaseAnalyticsQuickstart.UITests/FirebaseAnalyticsQuickstart.UITests.csproj
+++ b/samples/com.google.firebase/firebase-analytics/FirebaseAnalyticsQuickstart.UITests/FirebaseAnalyticsQuickstart.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FirebaseAnalyticsQuickstart.UITests</RootNamespace>
     <AssemblyName>FirebaseAnalyticsQuickstart.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.firebase/firebase-appindexing/AppIndexingSample.UITests/AppIndexingSample.UITests.csproj
+++ b/samples/com.google.firebase/firebase-appindexing/AppIndexingSample.UITests/AppIndexingSample.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AppIndexingSample.UITests</RootNamespace>
     <AssemblyName>AppIndexingSample.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.firebase/firebase-auth/FirebaseAuthQuickstart.UITests/FirebaseAuthQuickstart.UITests.csproj
+++ b/samples/com.google.firebase/firebase-auth/FirebaseAuthQuickstart.UITests/FirebaseAuthQuickstart.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FirebaseAuthQuickstart.UITests</RootNamespace>
     <AssemblyName>FirebaseAuthQuickstart.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.firebase/firebase-config/FirebaseConfigQuickstart.UITests/FirebaseConfigQuickstart.UITests.csproj
+++ b/samples/com.google.firebase/firebase-config/FirebaseConfigQuickstart.UITests/FirebaseConfigQuickstart.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FirebaseConfigQuickstart.UITests</RootNamespace>
     <AssemblyName>FirebaseConfigQuickstart.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.firebase/firebase-crash/FirebaseCrashReportingQuickstart.UITests/FirebaseCrashReportingQuickstart.UITests.csproj
+++ b/samples/com.google.firebase/firebase-crash/FirebaseCrashReportingQuickstart.UITests/FirebaseCrashReportingQuickstart.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FirebaseCrashReportingQuickstart.UITests</RootNamespace>
     <AssemblyName>FirebaseCrashReportingQuickstart.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.firebase/firebase-invites/FirebaseInvitesQuickstart.UITests/FirebaseInvitesQuickstart.UITests.csproj
+++ b/samples/com.google.firebase/firebase-invites/FirebaseInvitesQuickstart.UITests/FirebaseInvitesQuickstart.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FirebaseInvitesQuickstart.UITests</RootNamespace>
     <AssemblyName>FirebaseInvitesQuickstart.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.firebase/firebase-messaging/FirebaseMessagingQuickstart.UITests/FirebaseMessagingQuickstart.UITests.csproj
+++ b/samples/com.google.firebase/firebase-messaging/FirebaseMessagingQuickstart.UITests/FirebaseMessagingQuickstart.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FirebaseMessagingQuickstart.UITests</RootNamespace>
     <AssemblyName>FirebaseMessagingQuickstart.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/com.google.firebase/firebase-storage/FirebaseStorageQuickstart.UITests/FirebaseStorageQuickstart.UITests.csproj
+++ b/samples/com.google.firebase/firebase-storage/FirebaseStorageQuickstart.UITests/FirebaseStorageQuickstart.UITests.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FirebaseStorageQuickstart.UITests</RootNamespace>
     <AssemblyName>FirebaseStorageQuickstart.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Update to build agents with VS2022 instead of VS2019.  Also updates Xamarin.Android to d17.0.

This requires a newer version of `Android.Sdk.Legacy` that supports VS2022.

The new VMs do not have the .NET Framework 4.5 targeting pack, so tests were updated to 4.8:
```
error MSB3644: The reference assemblies for .NETFramework,Version=v4.5 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [C:\a\_work\1\s\samples\com.google.android.gms\play-services-ads\AdMobSample.UITests\AdMobSample.UITests.csproj]
```