### PR TITLE
Template set grpc only (other dependencies already merged)

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -10,7 +10,7 @@ pr:
 variables:
   AndroidBinderatorVersion: 0.5.3
   AndroidXMigrationVersion: 1.0.8
-  DotNetVersion: 6.0.100
+  DotNetVersion: 6.0.200
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
   LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d17-0-macos

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -10,7 +10,7 @@ pr:
 variables:
   AndroidBinderatorVersion: 0.5.3
   AndroidXMigrationVersion: 1.0.8
-  DotNetVersion: 6.0.200
+  DotNetVersion: 6.0.101
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
   LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d17-0-macos

--- a/config.json
+++ b/config.json
@@ -1699,30 +1699,7 @@
         "nugetVersion": "2.8.0",
         "nugetId": "Square.Picasso",
         "dependencyOnly": false,
-        "templateSet": "squareup-picasso"      },
-      {
-        "groupId": "io.grpc",
-        "artifactId": "grpc-android",
-        "version": "1.28.0",
-        "nugetVersion": "1.28.0",
-        "nugetId": "Xamarin.Grpc.Android",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "io.grpc",
-        "artifactId": "grpc-context",
-        "version": "1.28.0",
-        "nugetVersion": "1.28.0",
-        "nugetId": "Xamarin.Grpc.Context",
-        "dependencyOnly": true
-      },
-      {
-        "groupId": "io.grpc",
-        "artifactId": "grpc-okhttp",
-        "version": "1.28.0",
-        "nugetVersion": "1.28.0",
-        "nugetId": "Xamarin.Grpc.OkHttp",
-        "dependencyOnly": true
+        "templateSet": "squareup-picasso"
       },
       {
         "groupId": "io.grpc",
@@ -1730,7 +1707,8 @@
         "version": "1.28.0",
         "nugetVersion": "1.28.0",
         "nugetId": "Xamarin.Grpc.Protobuf.Lite",
-        "dependencyOnly": true
+        "dependencyOnly": false,
+        "templateSet": "grpc"
       },
       {
         "groupId": "io.grpc",
@@ -1738,7 +1716,53 @@
         "version": "1.28.0",
         "nugetVersion": "1.28.0",
         "nugetId": "Xamarin.Grpc.Stub",
-        "dependencyOnly": true
+        "dependencyOnly": false,
+        "templateSet": "grpc"
+      },
+      {
+        "groupId": "io.grpc",
+        "artifactId": "grpc-okhttp",
+        "version": "1.28.0",
+        "nugetVersion": "1.28.0",
+        "nugetId": "Xamarin.Grpc.OkHttp",
+        "dependencyOnly": false,
+        "templateSet": "grpc"
+      },
+      {
+        "groupId": "io.grpc",
+        "artifactId": "grpc-context",
+        "version": "1.28.0",
+        "nugetVersion": "1.28.0",
+        "nugetId": "Xamarin.Grpc.Context",
+        "dependencyOnly": false,
+        "templateSet": "grpc"
+      },
+      {
+        "groupId": "io.grpc",
+        "artifactId": "grpc-core",
+        "version": "1.28.0",
+        "nugetVersion": "1.28.0",
+        "nugetId": "Xamarin.Grpc.Core",
+        "dependencyOnly": false,
+        "templateSet": "grpc"
+      },
+      {
+        "groupId": "io.grpc",
+        "artifactId": "grpc-android",
+        "version": "1.28.0",
+        "nugetVersion": "1.28.0",
+        "nugetId": "Xamarin.Grpc.Android",
+        "dependencyOnly": false,
+        "templateSet": "grpc"
+      },
+      {
+        "groupId": "io.grpc",
+        "artifactId": "grpc-api",
+        "version": "1.28.0",
+        "nugetVersion": "1.28.0",
+        "nugetId": "Xamarin.Grpc.Api",
+        "dependencyOnly": false,
+        "templateSet": "grpc"
       },
       {
         "groupId": "io.reactivex.rxjava2",
@@ -1778,6 +1802,14 @@
         "version": "1.5.31",
         "nugetVersion": "1.5.31.2",
         "nugetId": "Xamarin.Kotlin.StdLib.Jdk8",
+        "dependencyOnly": true
+      },
+      {
+        "groupId": "com.google.code.gson",
+        "artifactId": "gson",
+        "version": "2.8.8",
+        "nugetVersion": "2.8.8.2",
+        "nugetId": "GoogleGson",
         "dependencyOnly": true
       }
     ],
@@ -2046,6 +2078,21 @@
           {
             "templateFile": "templates/squareup-okio/Project.cshtml",
              "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.csproj"
+          },
+          {
+            "templateFile": "source/GooglePlayServicesSolutionFilter.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.slnf"
+          }
+        ]
+      },
+      {
+        "name": "grpc",
+        "mavenRepositoryType": "MavenCentral",
+        "templates":
+        [
+          {
+            "templateFile": "templates/grpc/Project.cshtml",
+            "outputFileRule": "generated/{groupid}.{artifactid}/{groupid}.{artifactid}.csproj"
           },
           {
             "templateFile": "source/GooglePlayServicesSolutionFilter.cshtml",

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -199,21 +199,12 @@
     <PackageReference Update="Xamarin.Google.Guava.ListenableFuture" Version="1.0.0.2" />
     <PackageReference Update="Xamarin.Protobuf.JavaLite" Version="3.14.0" />
     <PackageReference Update="Xamarin.Protobuf.Lite" Version="3.0.1" />
-    <PackageReference Update="Square.OkHttp" Version="2.7.5.1" />
-    <PackageReference Update="Square.Retrofit" Version="1.9.0.1" />
-    <PackageReference Update="Square.OkIO" Version="2.10.0" />
-    <PackageReference Update="Square.OkHttp3" Version="4.9.2" />
-    <PackageReference Update="Square.OkHttp3.UrlConnection" Version="4.9.2" />
-    <PackageReference Update="Square.Picasso" Version="2.8.0" />
     <PackageReference Update="Square.OkHttp" Version="2.7.5.2" />
     <PackageReference Update="Square.Retrofit" Version="1.9.0.2" />
     <PackageReference Update="Square.OkIO" Version="2.10.0.1" />
     <PackageReference Update="Square.OkHttp3" Version="4.9.2.1" />
     <PackageReference Update="Square.OkHttp3.UrlConnection" Version="4.9.2.1" />
     <PackageReference Update="Square.Picasso" Version="2.8.0.1" />
-    <PackageReference Update="Xamarin.Grpc.Android" Version="1.28.0" />
-    <PackageReference Update="Xamarin.Grpc.Context" Version="1.28.0" />
-    <PackageReference Update="Xamarin.Grpc.OkHttp" Version="1.28.0" />
     <PackageReference Update="Xamarin.Grpc.Protobuf.Lite" Version="1.28.0" />
     <PackageReference Update="Xamarin.Grpc.Stub" Version="1.28.0" />
     <PackageReference Update="Xamarin.Grpc.OkHttp" Version="1.28.0" />

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -205,15 +205,18 @@
     <PackageReference Update="Square.OkHttp3" Version="4.9.2" />
     <PackageReference Update="Square.OkHttp3.UrlConnection" Version="4.9.2" />
     <PackageReference Update="Square.Picasso" Version="2.8.0" />
-    <PackageReference Update="Xamarin.Grpc.Android" Version="1.28.0" />
-    <PackageReference Update="Xamarin.Grpc.Context" Version="1.28.0" />
-    <PackageReference Update="Xamarin.Grpc.OkHttp" Version="1.28.0" />
     <PackageReference Update="Xamarin.Grpc.Protobuf.Lite" Version="1.28.0" />
     <PackageReference Update="Xamarin.Grpc.Stub" Version="1.28.0" />
+    <PackageReference Update="Xamarin.Grpc.OkHttp" Version="1.28.0" />
+    <PackageReference Update="Xamarin.Grpc.Context" Version="1.28.0" />
+    <PackageReference Update="Xamarin.Grpc.Core" Version="1.28.0" />
+    <PackageReference Update="Xamarin.Grpc.Android" Version="1.28.0" />
+    <PackageReference Update="Xamarin.Grpc.Api" Version="1.28.0" />
     <PackageReference Update="Xamarin.Android.ReactiveX.RxAndroid" Version="2.1.1" />
     <PackageReference Update="Xamarin.Android.ReactiveX.RxJava" Version="2.2.7" />
     <PackageReference Update="Xamarin.Kotlin.StdLib" Version="1.5.31.2" />
     <PackageReference Update="Xamarin.Kotlin.StdLib.Common" Version="1.5.31.2" />
     <PackageReference Update="Xamarin.Kotlin.StdLib.Jdk8" Version="1.5.31.2" />
+    <PackageReference Update="GoogleGson" Version="2.8.8.2" />
   </ItemGroup>
 </Project>

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -272,7 +272,7 @@
     }
     @if (@Model.NuGetPackageId == "Xamarin.Firebase.Firestore")
     {
-      <PackageReference Include="Xamarin.Google.Guava" Version="28.2.0.1" />
+      <PackageReference Include="Xamarin.Google.Guava" Version="29.0.0" />
     }
     @if (@Model.NuGetPackageId == "Xamarin.Firebase.Crashlytics")
     {

--- a/source/com.google.firebase/firebase-firestore/Transforms/Metadata.xml
+++ b/source/com.google.firebase/firebase-firestore/Transforms/Metadata.xml
@@ -266,8 +266,25 @@
         >
         Firebase.Firestore.Model.Value.FieldValue
     </attr>
-        
-        
+    <attr
+        path="/api/package[@name='com.google.firestore.v1']/class[@name='FirestoreGrpc.FirestoreStub']/method[@name='build' and count(parameter)=2 and parameter[1][@type='io.grpc.Channel'] and parameter[2][@type='io.grpc.CallOptions']]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>
+    <attr
+        path="/api/package[@name='com.google.firestore.v1']/class[@name='FirestoreGrpc.FirestoreBlockingStub']/method[@name='build' and count(parameter)=2 and parameter[1][@type='io.grpc.Channel'] and parameter[2][@type='io.grpc.CallOptions']]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>
+    <attr
+        path="/api/package[@name='com.google.firestore.v1']/class[@name='FirestoreGrpc.FirestoreFutureStub']/method[@name='build' and count(parameter)=2 and parameter[1][@type='io.grpc.Channel'] and parameter[2][@type='io.grpc.CallOptions']]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>
+
     <remove-node
         path="/api/package[@name='com.google.firebase.firestore.model.value']/class[@name='FieldValue']/method[@name='value' and count(parameter)=0]"
         />

--- a/source/com.google.firebase/firebase-inappmessaging/Transforms/Metadata.xml
+++ b/source/com.google.firebase/firebase-inappmessaging/Transforms/Metadata.xml
@@ -282,4 +282,24 @@
 
     <!-- Remove internal API that has covariant return issues -->
     <remove-node path="/api/package[@name='com.google.firebase.inappmessaging.dagger.internal']" />
+
+    <attr
+        path="/api/package[@name='com.google.internal.firebase.inappmessaging.v1.sdkserving']/class[@name='InAppMessagingSdkServingGrpc.InAppMessagingSdkServingStub']/method[@name='build' and count(parameter)=2 and parameter[1][@type='io.grpc.Channel'] and parameter[2][@type='io.grpc.CallOptions']]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>
+    <attr
+        path="/api/package[@name='com.google.internal.firebase.inappmessaging.v1.sdkserving']/class[@name='InAppMessagingSdkServingGrpc.InAppMessagingSdkServingBlockingStub']/method[@name='build' and count(parameter)=2 and parameter[1][@type='io.grpc.Channel'] and parameter[2][@type='io.grpc.CallOptions']]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>
+    <attr
+        path="/api/package[@name='com.google.internal.firebase.inappmessaging.v1.sdkserving']/class[@name='InAppMessagingSdkServingGrpc.InAppMessagingSdkServingFutureStub']/method[@name='build' and count(parameter)=2 and parameter[1][@type='io.grpc.Channel'] and parameter[2][@type='io.grpc.CallOptions']]"
+        name="managedReturn"
+        >
+        Java.Lang.Object
+    </attr>
+
 </metadata>

--- a/source/io.grpc/grpc-android/Additions/Additions.cs
+++ b/source/io.grpc/grpc-android/Additions/Additions.cs
@@ -1,0 +1,4 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;

--- a/source/io.grpc/grpc-android/Transforms/EnumFields.xml
+++ b/source/io.grpc/grpc-android/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/io.grpc/grpc-android/Transforms/EnumMethods.xml
+++ b/source/io.grpc/grpc-android/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/io.grpc/grpc-android/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-android/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,10 @@
+﻿<metadata>
+    <!--
+    <attr 
+        path="/api/package[@name='package']" 
+        name="managedName"
+        >
+        Package
+    </attr>
+    -->
+</metadata>

--- a/source/io.grpc/grpc-android/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-android/Transforms/Metadata.Namespaces.xml
@@ -1,10 +1,8 @@
 ﻿<metadata>
-    <!--
     <attr 
-        path="/api/package[@name='package']" 
+        path="/api/package[@name='io.grpc.android']" 
         name="managedName"
         >
-        Package
+        Xamarin.Grpc.Android
     </attr>
-    -->
 </metadata>

--- a/source/io.grpc/grpc-android/Transforms/Metadata.ParameterNames.xml
+++ b/source/io.grpc/grpc-android/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/io.grpc/grpc-android/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-android/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/io.grpc/grpc-api/Additions/Additions.cs
+++ b/source/io.grpc/grpc-api/Additions/Additions.cs
@@ -1,0 +1,4 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;

--- a/source/io.grpc/grpc-api/Additions/Xamarin.Grpc.CodecGzip.cs
+++ b/source/io.grpc/grpc-api/Additions/Xamarin.Grpc.CodecGzip.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;
+using Android.Runtime;
+
+namespace Xamarin.Grpc 
+{
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='io.grpc']/class[@name='Codec.Gzip']"
+	//[global::Android.Runtime.Register ("io/grpc/Codec$Gzip", DoNotGenerateAcw=true)]
+	public sealed partial class CodecGzip 
+    {
+ 		public unsafe string MessageEncodingCompressor
+        {
+			// Metadata.xml XPath method reference: path="/api/package[@name='io.grpc']/class[@name='Codec.Gzip']/method[@name='getMessageEncoding' and count(parameter)=0]"
+			[Register ("getMessageEncoding", "()Ljava/lang/String;", "")]
+			get {
+				const string __id = "getMessageEncoding.()Ljava/lang/String;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeAbstractObjectMethod (__id, this, null);
+					return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+
+ 		public unsafe string MessageEncodingDecompressor
+        {
+			// Metadata.xml XPath method reference: path="/api/package[@name='io.grpc']/class[@name='Codec.Gzip']/method[@name='getMessageEncoding' and count(parameter)=0]"
+			[Register ("getMessageEncoding", "()Ljava/lang/String;", "")]
+			get {
+				const string __id = "getMessageEncoding.()Ljava/lang/String;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeAbstractObjectMethod (__id, this, null);
+					return JNIEnv.GetString (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+   }
+}

--- a/source/io.grpc/grpc-api/Transforms/EnumFields.xml
+++ b/source/io.grpc/grpc-api/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/io.grpc/grpc-api/Transforms/EnumMethods.xml
+++ b/source/io.grpc/grpc-api/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/io.grpc/grpc-api/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-api/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,10 @@
+﻿<metadata>
+    <!--
+    <attr 
+        path="/api/package[@name='package']" 
+        name="managedName"
+        >
+        Package
+    </attr>
+    -->
+</metadata>

--- a/source/io.grpc/grpc-api/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-api/Transforms/Metadata.Namespaces.xml
@@ -1,10 +1,9 @@
 ﻿<metadata>
-    <!--
     <attr 
-        path="/api/package[@name='package']" 
+        path="/api/package[@name='io.grpc']" 
         name="managedName"
         >
-        Package
+        Xamarin.Grpc
     </attr>
-    -->
+    
 </metadata>

--- a/source/io.grpc/grpc-api/Transforms/Metadata.ParameterNames.xml
+++ b/source/io.grpc/grpc-api/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/io.grpc/grpc-api/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-api/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/io.grpc/grpc-api/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-api/Transforms/Metadata.xml
@@ -36,9 +36,6 @@
     <remove-node
         path="/api/package[@name='io.grpc']/class[@name='Codec.Identity']/method[@name='getMessageEncoding' and count(parameter)=0]"
         />
-    <remove-node
-        path="/api/package[@name='io.grpc']/class[@name='InternalMetadata']"
-        />
 
     <attr
         path="/api/package[@name='io.grpc']/class[@name='ManagedChannelProvider']/method[@name='priority' and count(parameter)=0]"
@@ -65,11 +62,46 @@
         path="/api/package[@name='io.grpc']/class[@name='ManagedChannelBuilder']/method[@name='intercept' and count(parameter)=1 and parameter[1][@type='java.util.List&lt;io.grpc.ClientInterceptor&gt;']]"
         />
     <remove-node
-        path="/api/package[@name='io.grpc.internal']/class[@name='AbstractManagedChannelImplBuilder']/typeParameters"
-        />
-    <remove-node
         path="/api/package[@name='io.grpc']/class[@name='ManagedChannelBuilder']/method[@name='intercept' and count(parameter)=1 and parameter[1][@type='io.grpc.ClientInterceptor...']]"
         />
 
+    <remove-node
+        path="/api/package[@name='io.grpc']/interface[@name='ServiceProviders.PriorityAccessor']/typeParameters"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/interface[@name='InternalServiceProviders.PriorityAccessor']/typeParameters"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/interface[@name='Metadata.TrustedAsciiMarshaller']/typeParameters"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/interface[@name='InternalMetadata.TrustedAsciiMarshaller']/typeParameters"
+        />
+
+    <!--
+    <remove-node
+        path="/api/package[@name='io.grpc']/class/typeParameters"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/class/method/typeParameters"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/interface/typeParameters"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/interface/method/typeParameters"
+        />
+
+    <add-node
+        path="/api/package[@name='io.grpc']/interface[@name='InternalMetadata.TrustedAsciiMarshaller']"
+        >
+      <method abstract="true" deprecated="not deprecated" final="false" name="parseAsciiString" jni-signature="([B)Ljava/lang/Object;" bridge="false" native="false" return="T" jni-return="TT;" static="false" synchronized="false" synthetic="false" visibility="public">
+        <parameter name="p0" type="byte[]" jni-type="[B"></parameter>
+      </method>
+      <method abstract="true" deprecated="not deprecated" final="false" name="toAsciiString" jni-signature="(Ljava/lang/Object;)[B" bridge="false" native="false" return="byte[]" jni-return="[B" static="false" synchronized="false" synthetic="false" visibility="public">
+        <parameter name="p0" type="T" jni-type="TT;"></parameter>
+      </method>
+    </add-node>
+    -->
 
 </metadata>

--- a/source/io.grpc/grpc-api/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-api/Transforms/Metadata.xml
@@ -53,11 +53,23 @@
         public
     </attr>
 
+
     <remove-node
         path="/api/package[@name='io.grpc']/class[@name='ManagedChannelProvider']/method[@name='builderForAddress' and count(parameter)=2 and parameter[1][@type='java.lang.String'] and parameter[2][@type='int']]"
         />
     <remove-node
         path="/api/package[@name='io.grpc']/class[@name='ManagedChannelProvider']/method[@name='builderForTarget' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
         />
+
+    <remove-node
+        path="/api/package[@name='io.grpc']/class[@name='ManagedChannelBuilder']/method[@name='intercept' and count(parameter)=1 and parameter[1][@type='java.util.List&lt;io.grpc.ClientInterceptor&gt;']]"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc.internal']/class[@name='AbstractManagedChannelImplBuilder']/typeParameters"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/class[@name='ManagedChannelBuilder']/method[@name='intercept' and count(parameter)=1 and parameter[1][@type='io.grpc.ClientInterceptor...']]"
+        />
+
 
 </metadata>

--- a/source/io.grpc/grpc-api/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-api/Transforms/Metadata.xml
@@ -1,3 +1,63 @@
 ﻿<metadata>
+    <remove-node
+        path="/api/package[@name='io.grpc']/class[@name='PartialForwardingClientCallListener']/method[@name='delegate' and count(parameter)=0]"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/class[@name='PartialForwardingServerCall']/method[@name='delegate' and count(parameter)=0]"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/class[@name='PartialForwardingServerCallListener']/method[@name='delegate' and count(parameter)=0]"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/class[@name='PartialForwardingClientCall']/method[@name='delegate' and count(parameter)=0]"
+        />
+
+    <!--
+    <attr
+        path="/api/package[@name='io.grpc']/interface[@name='Compressor']/method[@name='getMessageEncoding' and count(parameter)=0]"
+        name="managedName"
+        >
+        MessageEncodingCompressor
+    </attr>
+    <attr
+        path="/api/package[@name='io.grpc']/interface[@name='Decompressor']/method[@name='getMessageEncoding' and count(parameter)=0]"
+        name="managedName"
+        >
+        MessageEncodingDecompressor
+    </attr>
+    -->
+
+    <remove-node
+        path="/api/package[@name='io.grpc']/interface[@name='Compressor']/method[@name='getMessageEncoding' and count(parameter)=0]"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/interface[@name='Decompressor']/method[@name='getMessageEncoding' and count(parameter)=0]"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/class[@name='Codec.Identity']/method[@name='getMessageEncoding' and count(parameter)=0]"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/class[@name='InternalMetadata']"
+        />
+
+    <attr
+        path="/api/package[@name='io.grpc']/class[@name='ManagedChannelProvider']/method[@name='priority' and count(parameter)=0]"
+        name="visibility"
+        >
+        public
+    </attr>
+    <attr
+        path="/api/package[@name='io.grpc']/class[@name='ManagedChannelProvider']/method[@name='isAvailable' and count(parameter)=0]"
+        name="visibility"
+        >
+        public
+    </attr>
+
+    <remove-node
+        path="/api/package[@name='io.grpc']/class[@name='ManagedChannelProvider']/method[@name='builderForAddress' and count(parameter)=2 and parameter[1][@type='java.lang.String'] and parameter[2][@type='int']]"
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc']/class[@name='ManagedChannelProvider']/method[@name='builderForTarget' and count(parameter)=1 and parameter[1][@type='java.lang.String']]"
+        />
 
 </metadata>

--- a/source/io.grpc/grpc-context/Additions/Additions.cs
+++ b/source/io.grpc/grpc-context/Additions/Additions.cs
@@ -1,0 +1,4 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;

--- a/source/io.grpc/grpc-context/Transforms/EnumFields.xml
+++ b/source/io.grpc/grpc-context/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/io.grpc/grpc-context/Transforms/EnumMethods.xml
+++ b/source/io.grpc/grpc-context/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/io.grpc/grpc-context/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-context/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,10 @@
+﻿<metadata>
+    <!--
+    <attr 
+        path="/api/package[@name='package']" 
+        name="managedName"
+        >
+        Package
+    </attr>
+    -->
+</metadata>

--- a/source/io.grpc/grpc-context/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-context/Transforms/Metadata.Namespaces.xml
@@ -1,10 +1,8 @@
 ﻿<metadata>
-    <!--
     <attr 
-        path="/api/package[@name='package']" 
+        path="/api/package[@name='io.grpc']" 
         name="managedName"
         >
-        Package
+        Xamarin.Grpc
     </attr>
-    -->
 </metadata>

--- a/source/io.grpc/grpc-context/Transforms/Metadata.ParameterNames.xml
+++ b/source/io.grpc/grpc-context/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/io.grpc/grpc-context/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-context/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/io.grpc/grpc-context/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-context/Transforms/Metadata.xml
@@ -1,3 +1,9 @@
 ﻿<metadata>
-
+    <attr
+        path="/api/package[@name='io.grpc']/class[@name='Deadline']/method[@name='compareTo' and count(parameter)=1 and parameter[1][@type='io.grpc.Deadline']]/parameter[1]"
+        name="managedType"
+        >
+        Java.Lang.Object
+    </attr>
+    
 </metadata>

--- a/source/io.grpc/grpc-core/Additions/Additions.cs
+++ b/source/io.grpc/grpc-core/Additions/Additions.cs
@@ -2,3 +2,29 @@
 using Android.Views;
 using Android.Widget;
 using Android.Graphics;
+
+
+namespace Xamarin.Grpc.Core.InProcess 
+{
+	public sealed partial class InProcessChannelBuilder 
+    {
+		// public override unsafe global::Java.Lang.Object Intercept (params global::Xamarin.Grpc.IClientInterceptor[] p0)
+		// {
+		// 	const string __id = "intercept.([Lio/grpc/ClientInterceptor;)Lio/grpc/inprocess/InProcessChannelBuilder;";
+		// 	IntPtr native_p0 = JNIEnv.NewArray (p0);
+		// 	try {
+		// 		JniArgumentValue* __args = stackalloc JniArgumentValue [1];
+		// 		__args [0] = new JniArgumentValue (native_p0);
+		// 		var __rm = _members.InstanceMethods.InvokeAbstractObjectMethod (__id, this, __args);
+		// 		return (global::Java.Lang.Object) global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+		// 	} finally {
+		// 		if (p0 != null) {
+		// 			JNIEnv.CopyArray (native_p0, p0);
+		// 			JNIEnv.DeleteLocalRef (native_p0);
+		// 		}
+		// 		global::System.GC.KeepAlive (p0);
+		// 	}
+		// }
+        
+    }
+}

--- a/source/io.grpc/grpc-core/Additions/Additions.cs
+++ b/source/io.grpc/grpc-core/Additions/Additions.cs
@@ -1,0 +1,4 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;

--- a/source/io.grpc/grpc-core/Transforms/EnumFields.xml
+++ b/source/io.grpc/grpc-core/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/io.grpc/grpc-core/Transforms/EnumMethods.xml
+++ b/source/io.grpc/grpc-core/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/io.grpc/grpc-core/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-core/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,10 @@
+﻿<metadata>
+    <!--
+    <attr 
+        path="/api/package[@name='package']" 
+        name="managedName"
+        >
+        Package
+    </attr>
+    -->
+</metadata>

--- a/source/io.grpc/grpc-core/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-core/Transforms/Metadata.Namespaces.xml
@@ -1,10 +1,23 @@
 ﻿<metadata>
-    <!--
     <attr 
-        path="/api/package[@name='package']" 
+        path="/api/package[@name='io.grpc.inprocess']" 
         name="managedName"
         >
-        Package
+        Xamarin.Grpc.Core.InProcess
     </attr>
-    -->
+    <attr 
+        path="/api/package[@name='io.grpc.internal']" 
+        name="managedName"
+        >
+        Xamarin.Grpc.Core.Internal
+    </attr>
+    <attr 
+        path="/api/package[@name='io.grpc.util']" 
+        name="managedName"
+        >
+        Xamarin.Grpc.Core.Util
+    </attr>
+    
+    
+    
 </metadata>

--- a/source/io.grpc/grpc-core/Transforms/Metadata.ParameterNames.xml
+++ b/source/io.grpc/grpc-core/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/io.grpc/grpc-core/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-core/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/io.grpc/grpc-core/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-core/Transforms/Metadata.xml
@@ -1,3 +1,5 @@
 ﻿<metadata>
-
+    <remove-node
+        path="/api/package[@name='io.grpc.internal']"
+        />
 </metadata>

--- a/source/io.grpc/grpc-core/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-core/Transforms/Metadata.xml
@@ -1,5 +1,102 @@
 ﻿<metadata>
     <remove-node
-        path="/api/package[@name='io.grpc.internal']"
+        path="/api/package[@name='io.grpc.internal']/class[@name='AbstractManagedChannelImplBuilder']/typeParameters"
         />
+        
+    <attr
+        path="/api/package[@name='io.grpc.inprocess']/class"
+        name="visibility"
+        >
+        public
+    </attr>
+
+    <remove-node
+        path="/api/package[@name='io.grpc.internal']/class[@name='AbstractServerStream']"    
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc.internal']/class[@name='AbstractClientStream']"    
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc.internal']/class[@name='ServerImpl']"    
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc.internal']/class[@name='AbstractServerImplBuilder']"    
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc.internal']/class[@name='CompositeReadableBuffer']"    
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc.internal']/class[@name='MessageFramer']"    
+        />
+    <remove-node
+        path="/api/package[@name='io.grpc.internal']/class[@name='DnsNameResolverProvider']"    
+        />
+
+    <add-node
+        path="/api/package[@name='io.grpc.inprocess']/class[@name='InProcessChannelBuilder']"
+        >
+        <method 
+          visibility="public" static="false"  abstract="false" return="java.lang.Object" name="compressorRegistry" 
+          deprecated="not deprecated" final="false" bridge="false" native="false"  synchronized="false" synthetic="false" 
+          >
+          <parameter name="registry" type="io.grpc.CompressorRegistry" >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="decompressorRegistry" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+          <parameter name="registry" type="io.grpc.DecompressorRegistry" >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="directExecutor" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+        </method>
+        <method abstract="false" deprecated="not deprecated" final="false" name="executor" bridge="false" native="false" return="java.lang.Object" static="false" synchronized="false" synthetic="false" visibility="public">
+          <parameter name="executor" type="java.util.concurrent.Executor" >
+          </parameter>
+        </method>
+
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="idleTimeout" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+          <parameter name="value" type="long" >
+          </parameter>
+          <parameter name="unit" type="java.util.concurrent.TimeUnit" >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" override="true" abstract="false" return="java.lang.Object" name="intercept"
+          deprecated="not deprecated" final="false" bridge="false" native="false" ssynchronized="false" synthetic="false" 
+          >
+          <parameter name="interceptors" type="io.grpc.ClientInterceptor..." >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="nameResolverFactory" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+          <parameter name="resolverFactory" type="io.grpc.NameResolver.Factory" >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="overrideAuthority" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+          <parameter name="authority" type="java.lang.String" >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="userAgent" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+          <parameter name="userAgent" type="java.lang.String" >
+          </parameter>
+        </method>
+
+    </add-node>
+
 </metadata>

--- a/source/io.grpc/grpc-okhttp/Additions/Additions.cs
+++ b/source/io.grpc/grpc-okhttp/Additions/Additions.cs
@@ -1,0 +1,4 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;

--- a/source/io.grpc/grpc-okhttp/Transforms/EnumFields.xml
+++ b/source/io.grpc/grpc-okhttp/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/io.grpc/grpc-okhttp/Transforms/EnumMethods.xml
+++ b/source/io.grpc/grpc-okhttp/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/io.grpc/grpc-okhttp/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-okhttp/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,10 @@
+﻿<metadata>
+    <!--
+    <attr 
+        path="/api/package[@name='package']" 
+        name="managedName"
+        >
+        Package
+    </attr>
+    -->
+</metadata>

--- a/source/io.grpc/grpc-okhttp/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-okhttp/Transforms/Metadata.Namespaces.xml
@@ -1,10 +1,24 @@
 ﻿<metadata>
-    <!--
     <attr 
-        path="/api/package[@name='package']" 
+        path="/api/package[@name='io.grpc.okhttp']" 
         name="managedName"
         >
-        Package
+        Xamarin.Grpc.OkHttp
     </attr>
-    -->
+    <attr 
+        path="/api/package[@name='io.grpc.okhttp.internal']" 
+        name="managedName"
+        >
+        Xamarin.Grpc.OkHttp.Internal
+    </attr>
+    <attr 
+        path="/api/package[@name='io.grpc.okhttp.internal.framed']" 
+        name="managedName"
+        >
+        Xamarin.Grpc.OkHttp.Internal.Framed
+    </attr>
+
+    
+    
+    
 </metadata>

--- a/source/io.grpc/grpc-okhttp/Transforms/Metadata.ParameterNames.xml
+++ b/source/io.grpc/grpc-okhttp/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/io.grpc/grpc-okhttp/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-okhttp/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/io.grpc/grpc-okhttp/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-okhttp/Transforms/Metadata.xml
@@ -1,3 +1,70 @@
 ﻿<metadata>
 
+    <add-node
+        path="/api/package[@name='io.grpc.okhttp']/class[@name='OkHttpChannelBuilder']"
+        >
+        <method 
+          visibility="public" static="false"  abstract="false" return="java.lang.Object" name="compressorRegistry" 
+          deprecated="not deprecated" final="false" bridge="false" native="false"  synchronized="false" synthetic="false" 
+          >
+          <parameter name="registry" type="io.grpc.CompressorRegistry" >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="decompressorRegistry" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+          <parameter name="registry" type="io.grpc.DecompressorRegistry" >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="directExecutor" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+        </method>
+        <method abstract="false" deprecated="not deprecated" final="false" name="executor" bridge="false" native="false" return="java.lang.Object" static="false" synchronized="false" synthetic="false" visibility="public">
+          <parameter name="executor" type="java.util.concurrent.Executor" >
+          </parameter>
+        </method>
+
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="idleTimeout" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+          <parameter name="value" type="long" >
+          </parameter>
+          <parameter name="unit" type="java.util.concurrent.TimeUnit" >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" override="true" abstract="false" return="java.lang.Object" name="intercept"
+          deprecated="not deprecated" final="false" bridge="false" native="false" ssynchronized="false" synthetic="false" 
+          >
+          <parameter name="interceptors" type="io.grpc.ClientInterceptor..." >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="nameResolverFactory" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+          <parameter name="resolverFactory" type="io.grpc.NameResolver.Factory" >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="overrideAuthority" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+          <parameter name="authority" type="java.lang.String" >
+          </parameter>
+        </method>
+        <method 
+          visibility="public" static="false" abstract="false" return="java.lang.Object" name="userAgent" 
+          deprecated="not deprecated" final="false" bridge="false" native="false" synchronized="false" synthetic="false" 
+          >
+          <parameter name="userAgent" type="java.lang.String" >
+          </parameter>
+        </method>
+
+    </add-node>
+
 </metadata>

--- a/source/io.grpc/grpc-protobuf-lite/Additions/Additions.cs
+++ b/source/io.grpc/grpc-protobuf-lite/Additions/Additions.cs
@@ -1,0 +1,4 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;

--- a/source/io.grpc/grpc-protobuf-lite/Transforms/EnumFields.xml
+++ b/source/io.grpc/grpc-protobuf-lite/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/io.grpc/grpc-protobuf-lite/Transforms/EnumMethods.xml
+++ b/source/io.grpc/grpc-protobuf-lite/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/io.grpc/grpc-protobuf-lite/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-protobuf-lite/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,10 @@
+﻿<metadata>
+    <!--
+    <attr 
+        path="/api/package[@name='package']" 
+        name="managedName"
+        >
+        Package
+    </attr>
+    -->
+</metadata>

--- a/source/io.grpc/grpc-protobuf-lite/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-protobuf-lite/Transforms/Metadata.Namespaces.xml
@@ -1,10 +1,8 @@
 ﻿<metadata>
-    <!--
     <attr 
-        path="/api/package[@name='package']" 
+        path="/api/package[@name='protobuf.lite']" 
         name="managedName"
         >
-        Package
+        Xamarin.Grpc.Protobuf.Lite
     </attr>
-    -->
 </metadata>

--- a/source/io.grpc/grpc-protobuf-lite/Transforms/Metadata.ParameterNames.xml
+++ b/source/io.grpc/grpc-protobuf-lite/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/io.grpc/grpc-protobuf-lite/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-protobuf-lite/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/io.grpc/grpc-stub/Additions/Additions.cs
+++ b/source/io.grpc/grpc-stub/Additions/Additions.cs
@@ -1,0 +1,4 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;

--- a/source/io.grpc/grpc-stub/Transforms/EnumFields.xml
+++ b/source/io.grpc/grpc-stub/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/io.grpc/grpc-stub/Transforms/EnumMethods.xml
+++ b/source/io.grpc/grpc-stub/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/io.grpc/grpc-stub/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-stub/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,10 @@
+﻿<metadata>
+    <!--
+    <attr 
+        path="/api/package[@name='package']" 
+        name="managedName"
+        >
+        Package
+    </attr>
+    -->
+</metadata>

--- a/source/io.grpc/grpc-stub/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-stub/Transforms/Metadata.Namespaces.xml
@@ -1,10 +1,16 @@
 ﻿<metadata>
-    <!--
     <attr 
-        path="/api/package[@name='package']" 
+        path="/api/package[@name='io.grpc.stub']" 
         name="managedName"
         >
-        Package
+        Xamarin.Grpc.Stub
     </attr>
-    -->
+    <attr 
+        path="/api/package[@name='io.grpc.stub.annotations']" 
+        name="managedName"
+        >
+        Xamarin.Grpc.Stub.Annotations
+    </attr>
+    
+    
 </metadata>

--- a/source/io.grpc/grpc-stub/Transforms/Metadata.ParameterNames.xml
+++ b/source/io.grpc/grpc-stub/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/io.grpc/grpc-stub/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-stub/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/io.grpc/grpc-stub/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-stub/Transforms/Metadata.xml
@@ -2,5 +2,29 @@
     <remove-node
         path="/api/package[@name='io.grpc.stub']/interface[@name='StreamObserver']/typeParameters"
         />
+    <remove-node
+        path="/api/package[@name='io.grpc.stub']/interface[@name='StreamObserver']/method"
+        />
+    <add-node
+        path="/api/package[@name='io.grpc.stub']/interface[@name='StreamObserver']"
+        >
+        <method 
+            visibility="public" abstract="true" static="false" return="void" name="onCompleted"
+            deprecated="not deprecated" final="false"  bridge="false" native="false" synchronized="false" synthetic="false" 
+            >
+        </method>
+        <method 
+            abstract="true" 
+            deprecated="not deprecated" final="false" name="onError" bridge="false" native="false" return="void" static="false" synchronized="false" synthetic="false" visibility="public">
+            <parameter name="p0" type="java.lang.Throwable">
+            </parameter>
+        </method>
+        <method 
+            abstract="true" 
+            deprecated="not deprecated" final="false" name="onNext" bridge="false" native="false" return="void" static="false" synchronized="false" synthetic="false" visibility="public">
+            <parameter name="p0" type="java.lang.Object">
+            </parameter>
+        </method>
+    </add-node>
 
 </metadata>

--- a/source/io.grpc/grpc-stub/Transforms/Metadata.xml
+++ b/source/io.grpc/grpc-stub/Transforms/Metadata.xml
@@ -1,3 +1,6 @@
 ﻿<metadata>
+    <remove-node
+        path="/api/package[@name='io.grpc.stub']/interface[@name='StreamObserver']/typeParameters"
+        />
 
 </metadata>

--- a/templates/grpc/External-Dependency-Info.txt
+++ b/templates/grpc/External-Dependency-Info.txt
@@ -1,0 +1,220 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do not translate or localize
+
+Xamarin Components for Google GRPC incorporates 
+third party material from the projects listed below. The original copyright 
+notice and the license under which Microsoft received such third party 
+material are set forth below.  Microsoft reserves all other rights not 
+expressly granted, whether by implication, estoppel or otherwise.
+
+########################################
+# BEGIN:     Google GRPC
+# https://github.com/grpc/grpc
+########################################
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+########################################
+# END:      Google GRPC
+########################################
+

--- a/templates/grpc/LICENSE.md
+++ b/templates/grpc/LICENSE.md
@@ -1,0 +1,28 @@
+**Xamarin is not responsible for, nor does it grant any licenses to, third-party packages. 
+Some packages may require or install dependencies which are governed by additional licenses.**
+
+Note: This component depends on [OpenCensus](https://github.com/census-instrumentation)), 
+which is subject to the [Apache 2.0](https://github.com/census-instrumentation/opencensus-java/blob/master/LICENSE)
+
+### Xamarin Component for Google.Grpc for Xamarin.Android
+
+**The MIT License (MIT)**
+
+Copyright (c) .NET Foundation Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+and associated documentation files (the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES 
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+20190915

--- a/templates/grpc/Project.cshtml
+++ b/templates/grpc/Project.cshtml
@@ -1,0 +1,140 @@
+<Project Sdk="Xamarin.Legacy.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>MonoAndroid9.0;net6.0-android</TargetFrameworks>
+    <IsBindingProject>true</IsBindingProject>
+    <!--
+      No warnings for:
+       - CS0618: 'member' is obsolete: 'text'
+       - CS0109: The member 'member' does not hide an inherited member. The new keyword is not required
+       - CS0114: 'function1' hides inherited member 'function2'. To make the current method override that implementation, add the override keyword. Otherwise add the new keyword.
+       - CS0628: 'member' : new protected member declared in sealed class
+       - CS0108: 'member1' hides inherited member 'member2'. Use the new keyword if hiding was intended.
+       - CS0809: Obsolete member 'member' overrides non-obsolete member 'member'
+    -->
+    <NoWarn>0618;0109;0114;0628;0108;0809</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AndroidClassParser>class-parse</AndroidClassParser>
+    <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Microsoft</Authors>
+    <Owners>Microsoft</Owners>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865435</PackageLicenseUrl>
+    <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=865435</PackageProjectUrl>
+    <PackageLicenseUrl>https://go.microsoft.com/fwlink/?linkid=865373</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/tensorflow/tensorflow/</RepositoryUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+
+    @foreach (var art in @Model.MavenArtifacts) 
+    {
+      <PackageId>@Model.NuGetPackageId</PackageId>
+      <RootNamespace>@Model.NuGetPackageId</RootNamespace>
+      <AssemblyName>@Model.NuGetPackageId</AssemblyName>
+      switch(@Model.NuGetPackageId)
+      {
+          case "Xamarin.Grpc.Android":
+            <Title>Xamarin.Grpc.Android</Title>
+            <PackageDescription>
+                Bindings for Google's GRPC Android package
+            </PackageDescription>
+            <Summary>Bindings for Google's GRPC Android package</Summary>
+            <PackageTags>xamarin, android, bindings, google, grpc, android </PackageTags>
+            break; 
+          case "Xamarin.Grpc.Api":
+            <Title>Xamarin.Grpc.Api</Title>
+            <PackageDescription>
+                Bindings for Google's GRPC Api package
+            </PackageDescription>
+            <Summary>Bindings for Google's GRPC Api package</Summary>
+            <PackageTags>xamarin, android, bindings, google, grpc, api </PackageTags>
+            break; 
+          case "Xamarin.Grpc.Context":
+            <Title>Xamarin.Grpc.Context</Title>
+            <PackageDescription>
+                Bindings for Google's GRPC Context package
+            </PackageDescription>
+            <Summary>Bindings for Google's GRPC Context package</Summary>
+            <PackageTags>xamarin, android, bindings, google, grpc, context </PackageTags>
+            break; 
+          case "Xamarin.Grpc.Core":
+            <Title>Xamarin.Grpc.Core</Title>
+            <PackageDescription>
+                Bindings for Google's GRPC Core package
+            </PackageDescription>
+            <Summary>Bindings for Google's GRPC Core package</Summary>
+            <PackageTags>xamarin, android, bindings, google, grpc, core </PackageTags>
+            break; 
+          case "Xamarin.Grpc.OkHttp":
+            <Title>Xamarin.Grpc.OkHttp</Title>
+            <PackageDescription>
+                Bindings for Google's GRPC OkHttp package
+            </PackageDescription>
+            <Summary>Bindings for Google's GRPC OkHttp package</Summary>
+            <PackageTags>xamarin, android, bindings, google, grpc, okhttp </PackageTags>
+            break; 
+          case "Xamarin.Grpc.Protobuf.Lite":
+            <Title>Xamarin.Grpc.Protobuf.Lite</Title>
+            <PackageDescription>
+                Bindings for Google's GRPC Protobuf.Lite package
+            </PackageDescription>
+            <Summary>Bindings for Google's GRPC Protobuf.Lite package</Summary>
+            <PackageTags>xamarin, android, bindings, google, grpc, protobuf.lite, protobuf-lite, protobuf, lite </PackageTags>
+            break; 
+          case "Xamarin.Grpc.Stub":
+            <Title>Xamarin.Grpc.Stub</Title>
+            <PackageDescription>
+                Bindings for Google's GRPC Stub package
+            </PackageDescription>
+            <Summary>Bindings for Google's GRPC Stub package</Summary>
+            <PackageTags>xamarin, android, bindings, google, grpc, stub </PackageTags>
+            break; 
+          default:
+            break; 
+      }
+      <PackageVersion>@(Model.NuGetVersion)</PackageVersion>
+    }
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TransformFile Include="..\..\source\@(Model.MavenArtifacts[0].MavenGroupId)\@(Model.MavenArtifacts[0].MavenArtifactId)\Transforms\*.xml" Link="Transforms\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\source\@(Model.MavenArtifacts[0].MavenGroupId)\@(Model.MavenArtifacts[0].MavenArtifactId)\Additions\*.cs" Link="Additions\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    @foreach (var art in @Model.MavenArtifacts) 
+    {
+    <LibraryProjectZip 
+        Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).aar" Link="Jars\%(Filename)%(Extension)" 
+        Condition="Exists('..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).aar')"
+         />
+    <Embeddedjar 
+        Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" Link="Jars\%(Filename)%(Extension)" 
+        Condition="Exists('..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar')"
+        />
+    <JavaSourcesJar Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-sources.jar" Link="Jars\%(Filename)%(Extension)" />
+    }
+  </ItemGroup>
+
+  <ItemGroup>
+    @foreach (var dep in @Model.NuGetDependencies) {
+      if (dep.IsProjectReference) {
+    <ProjectReference Include="..\..\generated\@(dep.MavenArtifact.MavenGroupId).@(dep.MavenArtifact.MavenArtifactId)\@(dep.MavenArtifact.MavenGroupId).@(dep.MavenArtifact.MavenArtifactId).csproj" PrivateAssets="none" />
+      } else {
+    <PackageReference Include="@(dep.NuGetPackageId)" Version="@(dep.NuGetVersion)" />
+      }
+    }
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\templates\grpc\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
+    <None Include="..\..\templates\grpc\External-Dependency-Info.txt" Pack="true" PackagePath="THIRD-PARTY-NOTICES.txt" />
+  </ItemGroup>
+
+</Project>

--- a/templates/grpc/cgmanifest.json
+++ b/templates/grpc/cgmanifest.json
@@ -1,0 +1,82 @@
+{
+  "Registrations":[ 
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "google-context",
+          "GroupId": "io.grpc",
+          "Version": "1.37.0",
+          "NuGetId": "Xamarin.Grpc.Context"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "google-core",
+          "GroupId": "io.grpc",
+          "Version": "1.37.0",
+          "NuGetId": "Xamarin.Grpc.Core"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "google-stub",
+          "GroupId": "io.grpc",
+          "Version": "1.37.0",
+          "NuGetId": "Xamarin.Grpc.Stub"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "google-okhttp",
+          "GroupId": "io.grpc",
+          "Version": "1.37.0",
+          "NuGetId": "Xamarin.Grpc.OkHttp"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "google-protobuf",
+          "GroupId": "io.grpc",
+          "Version": "1.37.0",
+          "NuGetId": "Xamarin.Grpc.Protobuf.Lite"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "google-android",
+          "GroupId": "io.grpc",
+          "Version": "1.37.0",
+          "NuGetId": "Xamarin.Grpc.Android"
+        }
+      }
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "google-api",
+          "GroupId": "io.grpc",
+          "Version": "1.37.0",
+          "NuGetId": "Xamarin.Grpc.Api"
+        }
+      }
+    },
+  ],
+  "Version": 1
+}

--- a/templates/squareup-okhttp/Project.cshtml
+++ b/templates/squareup-okhttp/Project.cshtml
@@ -80,7 +80,6 @@
     <PackageReference Include="@(dep.NuGetPackageId)" Version="@(dep.NuGetVersion)" />
       }
     }
-    <PackageReference Include="Square.OkIO" Version="2.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Describe your contribution

1. moved `io.grpc.*` and `com.google.gson` bindings 
- `io.grpc:grpc-android` -  -> 1.28.0
- `io.grpc:grpc-api` -  -> 1.28.0
- `com.google.code.gson:gson` -  -> 2.8.8
  
2. created template sets

## Updated/new (moved) artifacts

- `io.grpc:grpc-android` -  -> 1.28.0
- `io.grpc:grpc-api` -  -> 1.28.0
- `com.google.code.gson:gson` -  -> 2.8.8

### Does this change any of the generated binding API's?

No.

`net6-android` TFM added



