### PR TITLE
OkHttp3 and OkHttp3UrlConnection 4.9.3

### DIFF
--- a/config.json
+++ b/config.json
@@ -1677,8 +1677,8 @@
       {
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp",
-        "version": "4.9.2",
-        "nugetVersion": "4.9.2.1",
+        "version": "4.9.3",
+        "nugetVersion": "4.9.3.0",
         "nugetId": "Square.OkHttp3",
         "dependencyOnly": false,
         "templateSet": "squareup-okhttp3"
@@ -1686,8 +1686,8 @@
       {
         "groupId": "com.squareup.okhttp3",
         "artifactId": "okhttp-urlconnection",
-        "version": "4.9.2",
-        "nugetVersion": "4.9.2.1",
+        "version": "4.9.3",
+        "nugetVersion": "4.9.3.0",
         "nugetId": "Square.OkHttp3.UrlConnection",
         "dependencyOnly": false,
         "templateSet": "squareup-okhttp3"

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -202,8 +202,8 @@
     <PackageReference Update="Square.OkHttp" Version="2.7.5.2" />
     <PackageReference Update="Square.Retrofit" Version="1.9.0.2" />
     <PackageReference Update="Square.OkIO" Version="2.10.0.1" />
-    <PackageReference Update="Square.OkHttp3" Version="4.9.2.1" />
-    <PackageReference Update="Square.OkHttp3.UrlConnection" Version="4.9.2.1" />
+    <PackageReference Update="Square.OkHttp3" Version="4.9.3.0" />
+    <PackageReference Update="Square.OkHttp3.UrlConnection" Version="4.9.3.0" />
     <PackageReference Update="Square.Picasso" Version="2.8.0.1" />
     <PackageReference Update="Xamarin.Grpc.Android" Version="1.28.0" />
     <PackageReference Update="Xamarin.Grpc.Context" Version="1.28.0" />

--- a/templates/squareup-okhttp3/cgmanifest.json
+++ b/templates/squareup-okhttp3/cgmanifest.json
@@ -6,7 +6,7 @@
         "maven": {
           "ArtifactId": "okhttp",
           "GroupId": "com.squareup.okhttp3",
-          "Version": "4.9.2",
+          "Version": "4.9.3",
           "NuGetId": "Square.OkHttp3"
         }
       }


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):

Bumps OkHttp3 and OkHttp3UrlConnection bind to 4.9.3

### Does this change any of the generated binding API's?

No.

### Describe your contribution

This PR bumps the OkHttp3 and OkHttp3UrlConnection bind to 4.9.3