### PR TITLE
Disable Mac CI.

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -35,7 +35,7 @@ jobs:
     parameters:
       timeoutInMinutes: 240
       areaPath: 'DevDiv\Xamarin SDK\Android'
-      macosImage: 'macOS-11'                                  # the name of the macOS VM image (BigSur)
+      macosImage:                                             # the name of the macOS VM image (BigSur) - Disabled until we have newer XA classic packages
       windowsAgentPoolName: android-win-2022
       xcode: 13.1
       dotnet: '5.0.403'                                       # the version of .NET Core to use


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/issues/470#issuecomment-1034009432

Previously, we began building our packages with `d17.0` releases.  However, there is no stable VSMac 2022 yet, so we are using preview packages of Xamarin.Android for this on Mac.  The build we are using contains a `Java.Interop.dll, 0.1.2.0` which is incorrect.

Both the Windows and Mac CI builds seem to copy the NuGets they created to the `nuget` archive folder when they complete building.  This is a "last man wins" situation, so if Windows CI takes longer, we release packages built on Windows.  If Mac CI takes longer, we release packages built on Mac (which are broken).

Until we have a stable XA for Mac that builds correct packages, we should disable the Mac lane so packages built on Mac are not published.