### PR TITLE
[ci] Generate a Software Bill of Materials

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -81,3 +81,11 @@ jobs:
         timeoutInMinutes: 120
         dependsOn: [ 'build' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+
+    - template: compliance/sbom/job.v1.yml@internal-templates
+      parameters:
+        dependsOn: signing
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+        artifactNames: [ nuget-signed ]
+        packageName: googleplayservices
+        packageFilter: '*.nupkg'

--- a/templates/codehaus-mojo/cgmanifest.json
+++ b/templates/codehaus-mojo/cgmanifest.json
@@ -6,7 +6,7 @@
           "Maven": {
             "ArtifactId": "gson",
             "GroupId": "com.google.code.gson",
-            "Version": "2.8.6"
+            "Version": "2.8.9"
           }
         }
       }


### PR DESCRIPTION
Context: https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/softwarebillofmaterials
Context: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
Context: https://github.com/xamarin/yaml-templates/blob/3a4be9e8fa257a139cec3014eb89a0fd5cd60b56/compliance/sbom/job.v1.yml
Context: https://devdiv.visualstudio.com/DevDiv/_componentGovernance/114855/alert/6201443

A new job has been added to generate a Software Bill of Materials using
shared yaml templates.

The com.google.code.gson dependency has also been updated to 2.8.9.