### PR TITLE
fix for template set glide - artifact not found in nuget (issue 545)

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,7 +29,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "annotations",
         "version": "4.12.0",
-        "nugetVersion": "4.12.0.5",
+        "nugetVersion": "4.12.0.6",
         "nugetId": "Xamarin.Android.Glide.Annotations",
         "dependencyOnly": false,
         "templateSet": "glide"
@@ -38,7 +38,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "disklrucache",
         "version": "4.12.0",
-        "nugetVersion": "4.12.0.5",
+        "nugetVersion": "4.12.0.6",
         "nugetId": "Xamarin.Android.Glide.DiskLruCache",
         "dependencyOnly": false,
         "templateSet": "glide"
@@ -47,7 +47,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "gifdecoder",
         "version": "4.12.0",
-        "nugetVersion": "4.12.0.5",
+        "nugetVersion": "4.12.0.6",
         "nugetId": "Xamarin.Android.Glide.GifDecoder",
         "dependencyOnly": false,
         "templateSet": "glide"
@@ -56,7 +56,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "glide",
         "version": "4.12.0",
-        "nugetVersion": "4.12.0.5",
+        "nugetVersion": "4.12.0.6",
         "nugetId": "Xamarin.Android.Glide",
         "dependencyOnly": false,
         "templateSet": "glide"
@@ -65,7 +65,7 @@
         "groupId": "com.github.bumptech.glide",
         "artifactId": "recyclerview-integration",
         "version": "4.12.0",
-        "nugetVersion": "4.12.0.5",
+        "nugetVersion": "4.12.0.6",
         "nugetId": "Xamarin.Android.Glide.RecyclerViewIntegration",
         "dependencyOnly": false,
         "templateSet": "glide"

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -1,10 +1,10 @@
 <Project>
   <ItemGroup>
-    <PackageReference Update="Xamarin.Android.Glide.Annotations" Version="4.12.0.5" />
-    <PackageReference Update="Xamarin.Android.Glide.DiskLruCache" Version="4.12.0.5" />
-    <PackageReference Update="Xamarin.Android.Glide.GifDecoder" Version="4.12.0.5" />
-    <PackageReference Update="Xamarin.Android.Glide" Version="4.12.0.5" />
-    <PackageReference Update="Xamarin.Android.Glide.RecyclerViewIntegration" Version="4.12.0.5" />
+    <PackageReference Update="Xamarin.Android.Glide.Annotations" Version="4.12.0.6" />
+    <PackageReference Update="Xamarin.Android.Glide.DiskLruCache" Version="4.12.0.6" />
+    <PackageReference Update="Xamarin.Android.Glide.GifDecoder" Version="4.12.0.6" />
+    <PackageReference Update="Xamarin.Android.Glide" Version="4.12.0.6" />
+    <PackageReference Update="Xamarin.Android.Glide.RecyclerViewIntegration" Version="4.12.0.6" />
     <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportApi" Version="3.0.0.1" />
     <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportBackendCct" Version="3.0.0.1" />
     <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="3.0.1.1" />

--- a/source/com.github.bumptech.glide/annotations/Xamarin.Android.Glide.Annotations.targets
+++ b/source/com.github.bumptech.glide/annotations/Xamarin.Android.Glide.Annotations.targets
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <AndroidJavaLibrary Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)..\..\jar\disklrucache.jar">
+    <AndroidJavaLibrary Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)..\..\jar\annotations.jar">
       <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
     </AndroidJavaLibrary>
   </ItemGroup>

--- a/source/com.github.bumptech.glide/disklrucache/Xamarin.Android.Glide.DiskLruCache.targets
+++ b/source/com.github.bumptech.glide/disklrucache/Xamarin.Android.Glide.DiskLruCache.targets
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <AndroidJavaLibrary Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)..\..\jar\annotations.jar">
+    <AndroidJavaLibrary Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)..\..\jar\disklrucache.jar">
       <AndroidXSkipAndroidXMigration>true</AndroidXSkipAndroidXMigration>
     </AndroidJavaLibrary>
   </ItemGroup>

--- a/templates/glide/Project.cshtml
+++ b/templates/glide/Project.cshtml
@@ -95,6 +95,9 @@
             <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" Pack="True" PackagePath="./jar" />
             <InputJar Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" />
             break; 
+          case "Xamarin.Android.Glide.Annotations":
+            <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).jar" Pack="True" PackagePath="./jar" />
+            break; 
           default:
             break; 
       }


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):


### Does this change any of the generated binding API's?


### Describe your contribution

During migration of template set from XamarinComponents `*.targets` files were copied into wrong destination folders (and renamed).

