### PR TITLE
Try only artifacts moving forward in version.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1418,8 +1418,8 @@
       {
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_annotations",
-        "version": "2.7.1",
-        "nugetVersion": "2.7.1",
+        "version": "2.14.0",
+        "nugetVersion": "2.14.0",
         "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "dependencyOnly": false,
         "templateSet": "errorprone"
@@ -1436,8 +1436,8 @@
       {
         "groupId": "com.google.protobuf",
         "artifactId": "protobuf-javalite",
-        "version": "3.17.3",
-        "nugetVersion": "3.17.3",
+        "version": "3.21.1",
+        "nugetVersion": "3.21.1",
         "nugetId": "Xamarin.Protobuf.JavaLite",
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "junit.junit,org.easymock.easymock,org.easymock.easymockclassextension,com.google.truth.truth",
@@ -1521,8 +1521,8 @@
       {
         "groupId": "io.grpc",
         "artifactId": "grpc-android",
-        "version": "1.43.2",
-        "nugetVersion": "1.43.2",
+        "version": "1.47.0",
+        "nugetVersion": "1.47.0",
         "nugetId": "Xamarin.Grpc.Android",
         "dependencyOnly": false,
         "templateSet": "grpc"
@@ -1530,8 +1530,8 @@
       {
         "groupId": "io.grpc",
         "artifactId": "grpc-api",
-        "version": "1.43.2",
-        "nugetVersion": "1.43.2",
+        "version": "1.47.0",
+        "nugetVersion": "1.47.0",
         "nugetId": "Xamarin.Grpc.Api",
         "dependencyOnly": false,
         "templateSet": "grpc"
@@ -1539,8 +1539,8 @@
       {
         "groupId": "io.grpc",
         "artifactId": "grpc-context",
-        "version": "1.43.2",
-        "nugetVersion": "1.43.2",
+        "version": "1.47.0",
+        "nugetVersion": "1.47.0",
         "nugetId": "Xamarin.Grpc.Context",
         "dependencyOnly": false,
         "templateSet": "grpc"
@@ -1548,8 +1548,8 @@
       {
         "groupId": "io.grpc",
         "artifactId": "grpc-core",
-        "version": "1.43.2",
-        "nugetVersion": "1.43.2",
+        "version": "1.47.0",
+        "nugetVersion": "1.47.0",
         "nugetId": "Xamarin.Grpc.Core",
         "dependencyOnly": false,
         "templateSet": "grpc"
@@ -1557,8 +1557,8 @@
       {
         "groupId": "io.grpc",
         "artifactId": "grpc-okhttp",
-        "version": "1.43.2",
-        "nugetVersion": "1.43.2",
+        "version": "1.47.0",
+        "nugetVersion": "1.47.0",
         "nugetId": "Xamarin.Grpc.OkHttp",
         "dependencyOnly": false,
         "templateSet": "grpc"
@@ -1566,8 +1566,8 @@
       {
         "groupId": "io.grpc",
         "artifactId": "grpc-protobuf-lite",
-        "version": "1.43.2",
-        "nugetVersion": "1.43.2",
+        "version": "1.47.0",
+        "nugetVersion": "1.47.0",
         "nugetId": "Xamarin.Grpc.Protobuf.Lite",
         "dependencyOnly": false,
         "templateSet": "grpc"
@@ -1575,8 +1575,8 @@
       {
         "groupId": "io.grpc",
         "artifactId": "grpc-stub",
-        "version": "1.43.2",
-        "nugetVersion": "1.43.2",
+        "version": "1.47.0",
+        "nugetVersion": "1.47.0",
         "nugetId": "Xamarin.Grpc.Stub",
         "dependencyOnly": false,
         "templateSet": "grpc"
@@ -1584,8 +1584,8 @@
       {
         "groupId": "io.opencensus",
         "artifactId": "opencensus-api",
-        "version": "0.30.0",
-        "nugetVersion": "0.30.0",
+        "version": "0.31.1",
+        "nugetVersion": "0.31.1",
         "nugetId": "Xamarin.Io.OpenCensus.OpenCensusApi",
         "dependencyOnly": false,
         "templateSet": "opencensus"
@@ -1593,8 +1593,8 @@
       {
         "groupId": "io.opencensus",
         "artifactId": "opencensus-contrib-grpc-metrics",
-        "version": "0.30.0",
-        "nugetVersion": "0.30.0",
+        "version": "0.31.1",
+        "nugetVersion": "0.31.1",
         "nugetId": "Xamarin.Io.OpenCensus.OpenCensusContribGrpcMetrics",
         "dependencyOnly": false,
         "templateSet": "opencensus"
@@ -1620,8 +1620,8 @@
       {
         "groupId": "org.chromium.net",
         "artifactId": "cronet-api",
-        "version": "94.4606.61",
-        "nugetVersion": "94.4606.61",
+        "version": "101.4951.41",
+        "nugetVersion": "101.4951.41",
         "nugetId": "Xamarin.Chromium.CroNet.Api",
         "dependencyOnly": false,
         "templateSet": "chromium-cronet"
@@ -1629,8 +1629,8 @@
       {
         "groupId": "org.chromium.net",
         "artifactId": "cronet-common",
-        "version": "94.4606.61",
-        "nugetVersion": "94.4606.61",
+        "version": "101.4951.41",
+        "nugetVersion": "101.4951.41",
         "nugetId": "Xamarin.Chromium.CroNet.Common",
         "dependencyOnly": false,
         "templateSet": "chromium-cronet"
@@ -1638,8 +1638,8 @@
       {
         "groupId": "org.chromium.net",
         "artifactId": "cronet-embedded",
-        "version": "94.4606.61",
-        "nugetVersion": "94.4606.61",
+        "version": "101.4951.41",
+        "nugetVersion": "101.4951.41",
         "nugetId": "Xamarin.Chromium.CroNet.Embedded",
         "dependencyOnly": false,
         "templateSet": "chromium-cronet"
@@ -1647,8 +1647,8 @@
       {
         "groupId": "org.chromium.net",
         "artifactId": "cronet-fallback",
-        "version": "94.4606.61",
-        "nugetVersion": "94.4606.61",
+        "version": "101.4951.41",
+        "nugetVersion": "101.4951.41",
         "nugetId": "Xamarin.Chromium.CroNet.Fallback",
         "dependencyOnly": false,
         "templateSet": "chromium-cronet"
@@ -1656,8 +1656,8 @@
       {
         "groupId": "org.codehaus.mojo",
         "artifactId": "animal-sniffer-annotations",
-        "version": "1.20",
-        "nugetVersion": "1.20.0",
+        "version": "1.21",
+        "nugetVersion": "1.21.0",
         "nugetId": "Xamarin.CodeHaus.Mojo.AnimalSnifferAnnotations",
         "dependencyOnly": false,
         "templateSet": "codehaus-mojo"
@@ -1665,8 +1665,8 @@
       {
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite",
-        "version": "2.7.0",
-        "nugetVersion": "2.7.0",
+        "version": "2.9.0",
+        "nugetVersion": "2.9.0",
         "nugetId": "Xamarin.TensorFlow.Lite",
         "dependencyOnly": false,
         "templateSet": "tensorflow-lite"
@@ -1674,8 +1674,8 @@
       {
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-api",
-        "version": "2.7.0",
-        "nugetVersion": "2.7.0",
+        "version": "2.9.0",
+        "nugetVersion": "2.9.0",
         "nugetId": "Xamarin.TensorFlow.Lite.Api",
         "dependencyOnly": false,
         "templateSet": "tensorflow-lite"
@@ -1683,8 +1683,8 @@
       {
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-gpu",
-        "version": "2.7.0",
-        "nugetVersion": "2.7.0",
+        "version": "2.9.0",
+        "nugetVersion": "2.9.0",
         "nugetId": "Xamarin.TensorFlow.Lite.Gpu",
         "dependencyOnly": false,
         "templateSet": "tensorflow-lite"
@@ -1928,8 +1928,8 @@
       {
         "groupId": "com.google.code.gson",
         "artifactId": "gson",
-        "version": "2.8.9",
-        "nugetVersion": "2.8.9.3",
+        "version": "2.9.0",
+        "nugetVersion": "2.9.0.2",
         "nugetId": "GoogleGson",
         "dependencyOnly": true
       },

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -43,9 +43,9 @@
     <PackageReference Update="Xamarin.GooglePlayServices.Measurement.Sdk.Api" Version="120.1.2" />
     <PackageReference Update="Xamarin.GooglePlayServices.MLKit.BarcodeScanning" Version="118.0.0" />
     <PackageReference Update="Xamarin.GooglePlayServices.MLKit.FaceDetection" Version="117.0.1" />
-    <PackageReference Update="Xamarin.GooglePlayServices.MLKit.ImageLabeling" Version="116.0.5" />
+    <PackageReference Update="Xamarin.GooglePlayServices.MLKit.ImageLabeling" Version="116.0.6" />
     <PackageReference Update="Xamarin.GooglePlayServices.MLKit.LanguageId" Version="117.0.0-beta1" />
-    <PackageReference Update="Xamarin.GooglePlayServices.MLKit.Text.Recognition" Version="117.0.1" />
+    <PackageReference Update="Xamarin.GooglePlayServices.MLKit.Text.Recognition" Version="118.0.0" />
     <PackageReference Update="Xamarin.GooglePlayServices.MLKit.Text.Recognition.Common" Version="117.0.0" />
     <PackageReference Update="Xamarin.GooglePlayServices.Nearby" Version="118.1.0" />
     <PackageReference Update="Xamarin.GooglePlayServices.Oss.Licenses" Version="117.0.0.5" />
@@ -57,10 +57,10 @@
     <PackageReference Update="Xamarin.GooglePlayServices.Places" Version="117.0.0.5" />
     <PackageReference Update="Xamarin.GooglePlayServices.Places.PlaceReport" Version="117.0.0.5" />
     <PackageReference Update="Xamarin.GooglePlayServices.Plus" Version="117.0.0.6" />
-    <PackageReference Update="Xamarin.GooglePlayServices.ReCaptcha" Version="116.0.1" />
+    <PackageReference Update="Xamarin.GooglePlayServices.Recaptcha" Version="116.0.1" />
     <PackageReference Update="Xamarin.GooglePlayServices.SafetyNet" Version="118.0.1" />
     <PackageReference Update="Xamarin.GooglePlayServices.Stats" Version="117.0.3" />
-    <PackageReference Update="Xamarin.GooglePlayServices.StreamPotect" Version="116.0.2" />
+    <PackageReference Update="Xamarin.GooglePlayServices.StreamProtect" Version="116.0.2.1" />
     <PackageReference Update="Xamarin.GooglePlayServices.TagManager" Version="118.0.1" />
     <PackageReference Update="Xamarin.GooglePlayServices.TagManager.Api" Version="118.0.1" />
     <PackageReference Update="Xamarin.GooglePlayServices.TagManager.V4.Impl" Version="118.0.1" />
@@ -172,9 +172,9 @@
     <PackageReference Update="Xamarin.Google.UserMessagingPlatform" Version="2.0.0" />
     <PackageReference Update="Xamarin.Google.Code.FindBugs.JSR305" Version="3.0.2.4" />
     <PackageReference Update="Xamarin.Google.Dagger" Version="2.42.0" />
-    <PackageReference Update="Xamarin.Google.ErrorProne.Annotations" Version="2.7.1" />
+    <PackageReference Update="Xamarin.Google.ErrorProne.Annotations" Version="2.14.0" />
     <PackageReference Update="Xamarin.Google.ZXing.Core" Version="3.5.0" />
-    <PackageReference Update="Xamarin.Protobuf.JavaLite" Version="3.17.3" />
+    <PackageReference Update="Xamarin.Protobuf.JavaLite" Version="3.21.1" />
     <PackageReference Update="Xamarin.Protobuf.Lite" Version="3.0.1.4" />
     <PackageReference Update="Square.OkHttp" Version="2.7.5.4" />
     <PackageReference Update="Square.OkHttp3" Version="4.9.3" />
@@ -183,25 +183,25 @@
     <PackageReference Update="Square.Picasso" Version="2.8.0.3" />
     <PackageReference Update="Square.Retrofit" Version="1.9.0.4" />
     <PackageReference Update="Square.JavaPoet" Version="1.13.0.0" />
-    <PackageReference Update="Xamarin.Grpc.Android" Version="1.43.2" />
-    <PackageReference Update="Xamarin.Grpc.Api" Version="1.43.2" />
-    <PackageReference Update="Xamarin.Grpc.Context" Version="1.43.2" />
-    <PackageReference Update="Xamarin.Grpc.Core" Version="1.43.2" />
-    <PackageReference Update="Xamarin.Grpc.OkHttp" Version="1.43.2" />
-    <PackageReference Update="Xamarin.Grpc.Protobuf.Lite" Version="1.43.2" />
-    <PackageReference Update="Xamarin.Grpc.Stub" Version="1.43.2" />
-    <PackageReference Update="Xamarin.Io.OpenCensus.OpenCensusApi" Version="0.30.0" />
-    <PackageReference Update="Xamarin.Io.OpenCensus.OpenCensusContribGrpcMetrics" Version="0.30.0" />
+    <PackageReference Update="Xamarin.Grpc.Android" Version="1.47.0" />
+    <PackageReference Update="Xamarin.Grpc.Api" Version="1.47.0" />
+    <PackageReference Update="Xamarin.Grpc.Context" Version="1.47.0" />
+    <PackageReference Update="Xamarin.Grpc.Core" Version="1.47.0" />
+    <PackageReference Update="Xamarin.Grpc.OkHttp" Version="1.47.0" />
+    <PackageReference Update="Xamarin.Grpc.Protobuf.Lite" Version="1.47.0" />
+    <PackageReference Update="Xamarin.Grpc.Stub" Version="1.47.0" />
+    <PackageReference Update="Xamarin.Io.OpenCensus.OpenCensusApi" Version="0.31.1" />
+    <PackageReference Update="Xamarin.Io.OpenCensus.OpenCensusContribGrpcMetrics" Version="0.31.1" />
     <PackageReference Update="Xamarin.Io.PerfMark.PerfMarkApi" Version="0.25.0" />
     <PackageReference Update="Xamarin.JavaX.Inject" Version="1.0.0.4" />
-    <PackageReference Update="Xamarin.Chromium.CroNet.Api" Version="94.4606.61" />
-    <PackageReference Update="Xamarin.Chromium.CroNet.Common" Version="94.4606.61" />
-    <PackageReference Update="Xamarin.Chromium.CroNet.Embedded" Version="94.4606.61" />
-    <PackageReference Update="Xamarin.Chromium.CroNet.Fallback" Version="94.4606.61" />
-    <PackageReference Update="Xamarin.CodeHaus.Mojo.AnimalSnifferAnnotations" Version="1.20.0" />
-    <PackageReference Update="Xamarin.TensorFlow.Lite" Version="2.7.0" />
-    <PackageReference Update="Xamarin.TensorFlow.Lite.API" Version="2.7.0" />
-    <PackageReference Update="Xamarin.TensorFlow.Lite.Gpu" Version="2.7.0" />
+    <PackageReference Update="Xamarin.Chromium.CroNet.Api" Version="101.4951.41" />
+    <PackageReference Update="Xamarin.Chromium.CroNet.Common" Version="101.4951.41" />
+    <PackageReference Update="Xamarin.Chromium.CroNet.Embedded" Version="101.4951.41" />
+    <PackageReference Update="Xamarin.Chromium.CroNet.Fallback" Version="101.4951.41" />
+    <PackageReference Update="Xamarin.CodeHaus.Mojo.AnimalSnifferAnnotations" Version="1.21.0" />
+    <PackageReference Update="Xamarin.TensorFlow.Lite" Version="2.9.0" />
+    <PackageReference Update="Xamarin.TensorFlow.Lite.Api" Version="2.9.0" />
+    <PackageReference Update="Xamarin.TensorFlow.Lite.Gpu" Version="2.9.0" />
     <PackageReference Update="Xamarin.AndroidX.Annotation" Version="1.3.0.3" />
     <PackageReference Update="Xamarin.AndroidX.AppCompat" Version="1.4.1.1" />
     <PackageReference Update="Xamarin.AndroidX.Browser" Version="1.4.0.1" />
@@ -231,7 +231,7 @@
     <PackageReference Update="Xamarin.GooglePlayServices.Measurement.Api" Version="116.3.0" />
     <PackageReference Update="Xamarin.GooglePlayServices.Measurement.Base" Version="117.0.1" />
     <PackageReference Update="Xamarin.Google.AutoValue.Annotations" Version="1.6.6" />
-    <PackageReference Update="GoogleGson" Version="2.8.9.3" />
+    <PackageReference Update="GoogleGson" Version="2.9.0.2" />
     <PackageReference Update="Xamarin.Firebase.Analytics" Version="116.3.0" />
     <PackageReference Update="Xamarin.Google.Guava" Version="31.1.0" />
     <PackageReference Update="Xamarin.Google.Guava.ListenableFuture" Version="1.0.0.6" />

--- a/source/io.grpc/grpc-okhttp/Transforms/Metadata.Namespaces.xml
+++ b/source/io.grpc/grpc-okhttp/Transforms/Metadata.Namespaces.xml
@@ -17,8 +17,10 @@
         >
         Xamarin.Grpc.OkHttp.Internal.Framed
     </attr>
-
-    
-    
-    
+    <attr 
+        path="/api/package[@name='io.grpc.okhttp.internal.proxy']" 
+        name="managedName"
+        >
+        Xamarin.Grpc.OkHttp.Internal.Proxy
+    </attr>
 </metadata>

--- a/source/org.tensorflow/tensorflow-lite-api/Transforms/Metadata.Namespaces.xml
+++ b/source/org.tensorflow/tensorflow-lite-api/Transforms/Metadata.Namespaces.xml
@@ -6,5 +6,11 @@
         >
         Xamarin.TensorFlow.Lite.Annotations
     </attr>
+    <attr 
+        path="/api/package[@name='org.tensorflow.lite.nnapi']" 
+        name="managedName"
+        >
+        Xamarin.TensorFlow.Lite.Nnapi
+    </attr>
 
 </metadata>


### PR DESCRIPTION
This is a suggested commit to https://github.com/xamarin/GooglePlayServicesComponents/pull/628.

It removes reverting any version numbers and seems to properly binderate and compile.