### PR TITLE
Re-enable Mac CI builds

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -9,13 +9,13 @@ pr:
   
 variables:
   AndroidBinderatorVersion: 0.5.4
-  AndroidXMigrationVersion: 1.0.9
+  AndroidXMigrationVersion: 1.0.10
   BootsVersion: 1.1.0.712-preview2
   DotNetVersion: 6.0.300
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
-  LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d17-0-macos
-  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-0-windows
+  LegacyXamarinAndroidPkg: https://aka.ms/xamarin-android-commercial-d17-2-macos
+  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-2-windows
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
 #   XAMARIN_ANDROID_PATH: <path to Xamarin.Android>
@@ -36,7 +36,7 @@ jobs:
     parameters:
       timeoutInMinutes: 240
       areaPath: 'DevDiv\Xamarin SDK\Android'
-      macosImage:                                             # the name of the macOS VM image (BigSur) - Disabled until we have newer XA classic packages
+      macosImage: macOS-11                                    # the name of the macOS VM image (BigSur)
       windowsAgentPoolName: android-win-2022
       xcode: 13.3.1
       dotnet: '6.0.300'                                       # the version of .NET Core to use


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No.

### Describe your contribution

MacOSX CI builds re-enabled (OSX image is not empty)