### PR TITLE
Update dotnet to `6.0.400` and classic to `17.3`.

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -11,15 +11,15 @@ variables:
   AndroidBinderatorVersion: 0.5.4
   AndroidXMigrationVersion: 1.0.10
   BootsVersion: 1.1.0.712-preview2
-  DotNetVersion: 6.0.300
+  DotNetVersion: 6.0.400
   XcodeVersion: 13.3.1
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
   XamarinDotNetWorkloadSource: workloads.json   # or url (check for recent versions - redth)
                                                 # https://aka.ms/dotnet/maui/6.0.400.json
   # matching builds
-  LegacyXamarinAndroidPkg:  https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/6454390/6.0.4xx/0b8d593a61bb49120fdf817e8dfdbc4b33937772/xamarin.android-12.3.99.117.pkg
-  LegacyXamarinAndroidVsix: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/6454390/6.0.4xx/0b8d593a61bb49120fdf817e8dfdbc4b33937772/Xamarin.Android.Sdk-12.3.99.117.vsix
+  LegacyXamarinAndroidPkg:  https://aka.ms/xamarin-android-commercial-d17-3-macos
+  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-3-windows
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
 #   XAMARIN_ANDROID_PATH: <path to Xamarin.Android>
@@ -51,10 +51,6 @@ jobs:
         - GoogleGson
         - Square
       initSteps:
-        - task: UseDotNet@2
-          displayName: install .NET $(DotNetVersion)
-          inputs:
-            version: $(DotNetVersion)
         - pwsh: |
             dotnet workload update --verbosity diag --from-rollback-file $(XamarinDotNetWorkloadSource) --source $(Dotnet6Source) --source $(NuGetOrgSource)
             dotnet workload install android --verbosity diag --skip-manifest-update --source $(Dotnet6Source) --source $(NuGetOrgSource)

--- a/workloads.json
+++ b/workloads.json
@@ -1,5 +1,5 @@
 {
-  "microsoft.net.sdk.android": "32.0.447/6.0.400",
+  "microsoft.net.sdk.android": "32.0.448/6.0.400",
   "microsoft.net.sdk.ios": "15.4.442/6.0.400",
   "microsoft.net.sdk.maccatalyst": "15.4.442/6.0.400",
   "microsoft.net.sdk.macos": "12.3.442/6.0.400",


### PR DESCRIPTION
Update:
- .NET 6 to `6.0.400`
- `microsoft.net.sdk.android` workload to `32.0.448`
- Classic to VS `17.3` versions (XA `13.0`)

Remove extraneous `UseDotNet` task now that we no longer use both `3.1` and `6.0`.  The base template will install `$(DotNetVersion)` for us.

- No API changes, as expected
- `<AndroidLibrary>` packages now include `.aar`:
![image](https://user-images.githubusercontent.com/179295/183764486-bcdd8af5-d428-470d-a46c-73ea94be5c70.png)
