### PR TITLE
Mu 20220901 fb only

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1111,9 +1111,9 @@
         "Maven": {
           "ArtifactId": "firebase-ads",
           "GroupId": "com.google.firebase",
-          "Version": "20.6.0",
+          "Version": "21.0.0",
           "NuGetId": "Xamarin.Firebase.Ads",
-          "NuGetVersion": "120.6.0"
+          "NuGetVersion": "121.0.0"
         }
       },
       "License": "The Apache Software License, Version 2.0"
@@ -1124,9 +1124,9 @@
         "Maven": {
           "ArtifactId": "firebase-ads-lite",
           "GroupId": "com.google.firebase",
-          "Version": "20.6.0",
+          "Version": "21.0.0",
           "NuGetId": "Xamarin.Firebase.Ads.Lite",
-          "NuGetVersion": "120.6.0"
+          "NuGetVersion": "121.0.0"
         }
       },
       "License": "The Apache Software License, Version 2.0"
@@ -1137,9 +1137,9 @@
         "Maven": {
           "ArtifactId": "firebase-analytics",
           "GroupId": "com.google.firebase",
-          "Version": "20.1.2",
+          "Version": "21.0.0",
           "NuGetId": "Xamarin.Firebase.Analytics",
-          "NuGetVersion": "120.1.2"
+          "NuGetVersion": "121.0.0"
         }
       },
       "License": "The Apache Software License, Version 2.0"
@@ -1153,6 +1153,19 @@
           "Version": "16.3.0",
           "NuGetId": "Xamarin.Firebase.Analytics.Impl",
           "NuGetVersion": "116.3.0.7"
+        }
+      },
+      "License": "The Apache Software License, Version 2.0"
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
+          "ArtifactId": "firebase-analytics-ktx",
+          "GroupId": "com.google.firebase",
+          "Version": "21.0.0",
+          "NuGetId": "Xamarin.Firebase.Analytics.Ktx",
+          "NuGetVersion": "121.0.0"
         }
       },
       "License": "The Apache Software License, Version 2.0"
@@ -1178,7 +1191,7 @@
           "GroupId": "com.google.firebase",
           "Version": "16.0.0",
           "NuGetId": "Xamarin.Firebase.AppCheck.Interop",
-          "NuGetVersion": "116.0.0"
+          "NuGetVersion": "116.0.0.7"
         }
       },
       "License": "The Apache Software License, Version 2.0"
@@ -1239,6 +1252,19 @@
       "Component": {
         "Type": "Maven",
         "Maven": {
+          "ArtifactId": "firebase-common-ktx",
+          "GroupId": "com.google.firebase",
+          "Version": "20.1.0",
+          "NuGetId": "Xamarin.Firebase.Common.Ktx",
+          "NuGetVersion": "120.1.0"
+        }
+      },
+      "License": "The Apache Software License, Version 2.0"
+    },
+    {
+      "Component": {
+        "Type": "Maven",
+        "Maven": {
           "ArtifactId": "firebase-components",
           "GroupId": "com.google.firebase",
           "Version": "17.0.0",
@@ -1267,9 +1293,9 @@
         "Maven": {
           "ArtifactId": "firebase-core",
           "GroupId": "com.google.firebase",
-          "Version": "20.0.2",
+          "Version": "20.1.2",
           "NuGetId": "Xamarin.Firebase.Core",
-          "NuGetVersion": "120.0.2.0"
+          "NuGetVersion": "120.1.2"
         }
       },
       "License": "The Apache Software License, Version 2.0"
@@ -1423,9 +1449,9 @@
         "Maven": {
           "ArtifactId": "firebase-firestore",
           "GroupId": "com.google.firebase",
-          "Version": "24.1.2",
+          "Version": "24.2.2",
           "NuGetId": "Xamarin.Firebase.Firestore",
-          "NuGetVersion": "124.1.2"
+          "NuGetVersion": "124.2.2"
         }
       },
       "License": "The Apache Software License, Version 2.0"
@@ -1436,9 +1462,9 @@
         "Maven": {
           "ArtifactId": "firebase-functions",
           "GroupId": "com.google.firebase",
-          "Version": "20.0.2",
+          "Version": "20.1.0",
           "NuGetId": "Xamarin.Firebase.Functions",
-          "NuGetVersion": "120.0.2"
+          "NuGetVersion": "120.1.0"
         }
       },
       "License": "The Apache Software License, Version 2.0"
@@ -1761,9 +1787,9 @@
         "Maven": {
           "ArtifactId": "firebase-perf",
           "GroupId": "com.google.firebase",
-          "Version": "20.0.6",
+          "Version": "20.1.0",
           "NuGetId": "Xamarin.Firebase.Perf",
-          "NuGetVersion": "120.0.6"
+          "NuGetVersion": "120.1.0"
         }
       },
       "License": "The Apache Software License, Version 2.0"
@@ -2088,7 +2114,7 @@
           "GroupId": "com.google.mlkit",
           "Version": "17.0.0",
           "NuGetId": "Xamarin.Google.MLKit.Translate",
-          "NuGetVersion": "117.0.0"
+          "NuGetVersion": "117.0.0.2"
         }
       },
       "License": "ML Kit Terms of Service"
@@ -2101,7 +2127,7 @@
           "GroupId": "com.google.mlkit",
           "Version": "17.1.0",
           "NuGetId": "Xamarin.Google.MLKit.Vision.Common",
-          "NuGetVersion": "117.1.0"
+          "NuGetVersion": "117.1.0.2"
         }
       },
       "License": "ML Kit Terms of Service"
@@ -2359,9 +2385,9 @@
         "Maven": {
           "ArtifactId": "error_prone_annotations",
           "GroupId": "com.google.errorprone",
-          "Version": "2.10.0",
+          "Version": "2.11.0",
           "NuGetId": "Xamarin.Google.ErrorProne.Annotations",
-          "NuGetVersion": "2.10.0.2"
+          "NuGetVersion": "2.11.0"
         }
       },
       "License": "The Apache Software License, Version 2.0"

--- a/config.json
+++ b/config.json
@@ -708,24 +708,24 @@
       {
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ads",
-        "version": "20.6.0",
-        "nugetVersion": "120.6.0",
+        "version": "21.0.0",
+        "nugetVersion": "121.0.0",
         "nugetId": "Xamarin.Firebase.Ads",
         "dependencyOnly": false
       },
       {
         "groupId": "com.google.firebase",
         "artifactId": "firebase-ads-lite",
-        "version": "20.6.0",
-        "nugetVersion": "120.6.0",
+        "version": "21.0.0",
+        "nugetVersion": "121.0.0",
         "nugetId": "Xamarin.Firebase.Ads.Lite",
         "dependencyOnly": false
       },
       {
         "groupId": "com.google.firebase",
         "artifactId": "firebase-analytics",
-        "version": "20.1.2",
-        "nugetVersion": "120.1.2",
+        "version": "21.0.0",
+        "nugetVersion": "121.0.0",
         "nugetId": "Xamarin.Firebase.Analytics",
         "dependencyOnly": false
       },
@@ -735,6 +735,14 @@
         "version": "16.3.0",
         "nugetVersion": "116.3.0.7",
         "nugetId": "Xamarin.Firebase.Analytics.Impl",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "com.google.firebase",
+        "artifactId": "firebase-analytics-ktx",
+        "version": "21.0.0",
+        "nugetVersion": "121.0.0",
+        "nugetId": "Xamarin.Firebase.Analytics.Ktx",
         "dependencyOnly": false
       },
       {
@@ -787,6 +795,14 @@
       },
       {
         "groupId": "com.google.firebase",
+        "artifactId": "firebase-common-ktx",
+        "version": "20.1.0",
+        "nugetVersion": "120.1.0",
+        "nugetId": "Xamarin.Firebase.Common.Ktx",
+        "dependencyOnly": false
+      },
+      {
+        "groupId": "com.google.firebase",
         "artifactId": "firebase-components",
         "version": "17.0.0",
         "nugetVersion": "117.0.0.7",
@@ -804,8 +820,8 @@
       {
         "groupId": "com.google.firebase",
         "artifactId": "firebase-core",
-        "version": "20.0.2",
-        "nugetVersion": "120.0.2.0",
+        "version": "20.1.2",
+        "nugetVersion": "120.1.2",
         "nugetId": "Xamarin.Firebase.Core",
         "dependencyOnly": false
       },
@@ -900,16 +916,16 @@
       {
         "groupId": "com.google.firebase",
         "artifactId": "firebase-firestore",
-        "version": "24.1.2",
-        "nugetVersion": "124.1.2",
+        "version": "24.2.2",
+        "nugetVersion": "124.2.2",
         "nugetId": "Xamarin.Firebase.Firestore",
         "dependencyOnly": false
       },
       {
         "groupId": "com.google.firebase",
         "artifactId": "firebase-functions",
-        "version": "20.0.2",
-        "nugetVersion": "120.0.2",
+        "version": "20.1.0",
+        "nugetVersion": "120.1.0",
         "nugetId": "Xamarin.Firebase.Functions",
         "dependencyOnly": false
       },
@@ -1116,8 +1132,8 @@
       {
         "groupId": "com.google.firebase",
         "artifactId": "firebase-perf",
-        "version": "20.0.6",
-        "nugetVersion": "120.0.6",
+        "version": "20.1.0",
+        "nugetVersion": "120.1.0",
         "nugetId": "Xamarin.Firebase.Perf",
         "dependencyOnly": false
       },
@@ -1496,8 +1512,8 @@
       {
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_annotations",
-        "version": "2.10.0",
-        "nugetVersion": "2.10.0.2",
+        "version": "2.11.0",
+        "nugetVersion": "2.11.0",
         "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "dependencyOnly": false,
         "templateSet": "errorprone"

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -85,19 +85,21 @@
     <PackageReference Update="Xamarin.Google.Android.Play.Feature.Delivery.Ktx" Version="2.0.0" />
     <PackageReference Update="Xamarin.Google.Android.Play.Integrity" Version="1.0.0.2" />
     <PackageReference Update="Xamarin.Firebase.Abt" Version="121.0.1" />
-    <PackageReference Update="Xamarin.Firebase.Ads" Version="120.6.0" />
-    <PackageReference Update="Xamarin.Firebase.Ads.Lite" Version="120.6.0" />
-    <PackageReference Update="Xamarin.Firebase.Analytics" Version="120.1.2" />
+    <PackageReference Update="Xamarin.Firebase.Ads" Version="121.0.0" />
+    <PackageReference Update="Xamarin.Firebase.Ads.Lite" Version="121.0.0" />
+    <PackageReference Update="Xamarin.Firebase.Analytics" Version="121.0.0" />
     <PackageReference Update="Xamarin.Firebase.Analytics.Impl" Version="116.3.0.7" />
+    <PackageReference Update="Xamarin.Firebase.Analytics.Ktx" Version="121.0.0" />
     <PackageReference Update="Xamarin.Firebase.Annotations" Version="116.1.0" />
-    <PackageReference Update="Xamarin.Firebase.AppCheck.Interop" Version="116.0.0" />
+    <PackageReference Update="Xamarin.Firebase.AppCheck.Interop" Version="116.0.0.7" />
     <PackageReference Update="Xamarin.Firebase.AppIndexing" Version="120.0.0.9" />
     <PackageReference Update="Xamarin.Firebase.Auth" Version="121.0.7" />
     <PackageReference Update="Xamarin.Firebase.Auth.Interop" Version="120.0.0.7" />
     <PackageReference Update="Xamarin.Firebase.Common" Version="120.1.1" />
+    <PackageReference Update="Xamarin.Firebase.Common.Ktx" Version="120.1.0" />
     <PackageReference Update="Xamarin.Firebase.Components" Version="117.0.0.7" />
     <PackageReference Update="Xamarin.Firebase.Config" Version="121.1.1" />
-    <PackageReference Update="Xamarin.Firebase.Core" Version="120.0.2.0" />
+    <PackageReference Update="Xamarin.Firebase.Core" Version="120.1.2" />
     <PackageReference Update="Xamarin.Firebase.Crash" Version="116.2.1.7" />
     <PackageReference Update="Xamarin.Firebase.Crashlytics" Version="118.2.12" />
     <PackageReference Update="Xamarin.Firebase.Crashlytics.NDK" Version="118.2.12" />
@@ -109,8 +111,8 @@
     <PackageReference Update="Xamarin.Firebase.Encoders" Version="117.0.0.7" />
     <PackageReference Update="Xamarin.Firebase.Encoders.JSON" Version="118.0.0.7" />
     <PackageReference Update="Xamarin.Firebase.Encoders.Proto" Version="116.0.0.2" />
-    <PackageReference Update="Xamarin.Firebase.Firestore" Version="124.1.2" />
-    <PackageReference Update="Xamarin.Firebase.Functions" Version="120.0.2" />
+    <PackageReference Update="Xamarin.Firebase.Firestore" Version="124.2.2" />
+    <PackageReference Update="Xamarin.Firebase.Functions" Version="120.1.0" />
     <PackageReference Update="Xamarin.Firebase.Iid" Version="121.1.0.7" />
     <PackageReference Update="Xamarin.Firebase.Iid.Interop" Version="117.1.0.7" />
     <PackageReference Update="Xamarin.Firebase.InAppMessaging" Version="120.1.2" />
@@ -136,7 +138,7 @@
     <PackageReference Update="Xamarin.Firebase.ML.Vision.Image.Label.Model" Version="120.0.2.7" />
     <PackageReference Update="Xamarin.Firebase.ML.Vision.Internal.Vkp" Version="117.0.2.7" />
     <PackageReference Update="Xamarin.Firebase.ML.Vision.Object.Detection.Model" Version="119.0.6.7" />
-    <PackageReference Update="Xamarin.Firebase.Perf" Version="120.0.6" />
+    <PackageReference Update="Xamarin.Firebase.Perf" Version="120.1.0" />
     <PackageReference Update="Xamarin.Firebase.Storage" Version="120.0.1" />
     <PackageReference Update="Xamarin.Firebase.Storage.Common" Version="117.0.0.7" />
     <PackageReference Update="Xamarin.Firebase.ProtoliteWellKnownTypes" Version="118.0.0.7" />
@@ -161,8 +163,8 @@
     <PackageReference Update="Xamarin.Google.MLKit.PoseDetection.Accurate" Version="117.0.0.7" />
     <PackageReference Update="Xamarin.Google.MLKit.PoseDetection.Common" Version="117.0.0.7" />
     <PackageReference Update="Xamarin.Google.MLKit.SmartReply" Version="117.0.1" />
-    <PackageReference Update="Xamarin.Google.MLKit.Translate" Version="117.0.0" />
-    <PackageReference Update="Xamarin.Google.MLKit.Vision.Common" Version="117.1.0" />
+    <PackageReference Update="Xamarin.Google.MLKit.Translate" Version="117.0.0.2" />
+    <PackageReference Update="Xamarin.Google.MLKit.Vision.Common" Version="117.1.0.2" />
     <PackageReference Update="Xamarin.Google.MLKit.Vision.Interfaces" Version="116.1.0" />
     <PackageReference Update="Xamarin.Google.MLKit.Vision.Internal.Vkp" Version="118.2.2.2" />
     <PackageReference Update="Xamarin.Google.Android.ODML.Image" Version="1.0.0.2-beta1" />
@@ -182,7 +184,7 @@
     <PackageReference Update="Xamarin.Google.UserMessagingPlatform" Version="2.0.0.2" />
     <PackageReference Update="Xamarin.Google.Code.FindBugs.JSR305" Version="3.0.2.6" />
     <PackageReference Update="Xamarin.Google.Dagger" Version="2.41.0.2" />
-    <PackageReference Update="Xamarin.Google.ErrorProne.Annotations" Version="2.10.0.2" />
+    <PackageReference Update="Xamarin.Google.ErrorProne.Annotations" Version="2.11.0" />
     <PackageReference Update="Xamarin.Google.ZXing.Core" Version="3.5.0.2" />
     <PackageReference Update="Xamarin.Protobuf.JavaLite" Version="3.19.2.2" />
     <PackageReference Update="Xamarin.Protobuf.Lite" Version="3.0.1.6" />

--- a/source/com.google.firebase/firebase-analytics-ktx/Additions/Additions.cs
+++ b/source/com.google.firebase/firebase-analytics-ktx/Additions/Additions.cs
@@ -1,0 +1,4 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;

--- a/source/com.google.firebase/firebase-analytics-ktx/Transforms/EnumFields.xml
+++ b/source/com.google.firebase/firebase-analytics-ktx/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/com.google.firebase/firebase-analytics-ktx/Transforms/EnumMethods.xml
+++ b/source/com.google.firebase/firebase-analytics-ktx/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/com.google.firebase/firebase-analytics-ktx/Transforms/Metadata.Namespaces.xml
+++ b/source/com.google.firebase/firebase-analytics-ktx/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,9 @@
+﻿<metadata>
+    <attr 
+        path="/api/package[@name='com.google.firebase.analytics.ktx']" 
+        name="managedName"
+        >
+        Firebase.Analytics.Ktx
+    </attr>
+
+</metadata>

--- a/source/com.google.firebase/firebase-analytics-ktx/Transforms/Metadata.ParameterNames.xml
+++ b/source/com.google.firebase/firebase-analytics-ktx/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/com.google.firebase/firebase-analytics-ktx/Transforms/Metadata.xml
+++ b/source/com.google.firebase/firebase-analytics-ktx/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>

--- a/source/com.google.firebase/firebase-common-ktx/Additions/Additions.cs
+++ b/source/com.google.firebase/firebase-common-ktx/Additions/Additions.cs
@@ -1,0 +1,4 @@
+﻿using System;
+using Android.Views;
+using Android.Widget;
+using Android.Graphics;

--- a/source/com.google.firebase/firebase-common-ktx/Transforms/EnumFields.xml
+++ b/source/com.google.firebase/firebase-common-ktx/Transforms/EnumFields.xml
@@ -1,0 +1,2 @@
+﻿<enum-field-mappings>
+</enum-field-mappings>

--- a/source/com.google.firebase/firebase-common-ktx/Transforms/EnumMethods.xml
+++ b/source/com.google.firebase/firebase-common-ktx/Transforms/EnumMethods.xml
@@ -1,0 +1,2 @@
+﻿<enum-method-mappings>
+</enum-method-mappings>

--- a/source/com.google.firebase/firebase-common-ktx/Transforms/Metadata.Namespaces.xml
+++ b/source/com.google.firebase/firebase-common-ktx/Transforms/Metadata.Namespaces.xml
@@ -1,0 +1,8 @@
+﻿<metadata>
+    <attr 
+        path="/api/package[@name='com.google.firebase.ktx']" 
+        name="managedName"
+        >
+        Firebase.Ktx
+    </attr>
+</metadata>

--- a/source/com.google.firebase/firebase-common-ktx/Transforms/Metadata.ParameterNames.xml
+++ b/source/com.google.firebase/firebase-common-ktx/Transforms/Metadata.ParameterNames.xml
@@ -1,0 +1,2 @@
+﻿<metadata>
+</metadata>

--- a/source/com.google.firebase/firebase-common-ktx/Transforms/Metadata.xml
+++ b/source/com.google.firebase/firebase-common-ktx/Transforms/Metadata.xml
@@ -1,0 +1,3 @@
+﻿<metadata>
+
+</metadata>


### PR DESCRIPTION
### Does this change any of the generated binding API's?

Most likely.

### Describe your contribution

updates + dependencies

- `com.google.firebase:firebase-ads` - 20.6.0 -> 21.0.0
- `com.google.firebase:firebase-ads-lite` - 20.6.0 -> 21.0.0
- `com.google.firebase:firebase-analytics` - 20.1.2 -> 21.0.0
- `com.google.firebase:firebase-analytics-ktx` -  -> 21.0.0
- `com.google.firebase:firebase-common-ktx` -  -> 20.1.0
- `com.google.firebase:firebase-core` - 20.0.2 -> 20.1.2
- `com.google.firebase:firebase-firestore` - 24.1.2 -> 24.2.2
- `com.google.firebase:firebase-functions` - 20.0.2 -> 20.1.0
- `com.google.firebase:firebase-perf` - 20.0.6 -> 20.1.0
- `com.google.errorprone:error_prone_annotations` - 2.10.0 -> 2.11.0
