### PR TITLE
Manual updates 20221004 MLKit only

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2204,9 +2204,9 @@
         "maven": {
           "artifactId": "vision-common",
           "groupId": "com.google.mlkit",
-          "version": "17.2.0",
+          "version": "17.2.1",
           "nuGetId": "Xamarin.Google.MLKit.Vision.Common",
-          "nuGetVersion": "117.2.0"
+          "nuGetVersion": "117.2.1"
         }
       },
       "license": "ML Kit Terms of Service"

--- a/config.json
+++ b/config.json
@@ -1388,8 +1388,8 @@
       {
         "groupId": "com.google.mlkit",
         "artifactId": "vision-common",
-        "version": "17.2.0",
-        "nugetVersion": "117.2.0",
+        "version": "17.2.1",
+        "nugetVersion": "117.2.1",
         "nugetId": "Xamarin.Google.MLKit.Vision.Common",
         "dependencyOnly": false
       },

--- a/docs/artifact-list-with-versions.md
+++ b/docs/artifact-list-with-versions.md
@@ -174,7 +174,7 @@
 | 167|com.google.mlkit:smart-reply                                          |17.0.2              |Xamarin.Google.MLKit.SmartReply                                       |117.0.2             |
 | 168|com.google.mlkit:smart-reply-common                                   |16.0.0              |Xamarin.Google.MLKit.SmartReply.Common                                |116.0.0             |
 | 169|com.google.mlkit:translate                                            |17.0.1              |Xamarin.Google.MLKit.Translate                                        |117.0.1             |
-| 170|com.google.mlkit:vision-common                                        |17.2.0              |Xamarin.Google.MLKit.Vision.Common                                    |117.2.0             |
+| 170|com.google.mlkit:vision-common                                        |17.2.1              |Xamarin.Google.MLKit.Vision.Common                                    |117.2.1             |
 | 171|com.google.mlkit:vision-interfaces                                    |16.1.0              |Xamarin.Google.MLKit.Vision.Interfaces                                |116.1.0             |
 | 172|com.google.mlkit:vision-internal-vkp                                  |18.2.2              |Xamarin.Google.MLKit.Vision.Internal.Vkp                              |118.2.2.2           |
 | 173|com.google.android.odml:image                                         |1.0.0-beta1         |Xamarin.Google.Android.ODML.Image                                     |1.0.0.2-beta1       |

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -170,7 +170,7 @@
     <PackageReference Update="Xamarin.Google.MLKit.SmartReply" Version="117.0.2" />
     <PackageReference Update="Xamarin.Google.MLKit.SmartReply.Common" Version="116.0.0" />
     <PackageReference Update="Xamarin.Google.MLKit.Translate" Version="117.0.1" />
-    <PackageReference Update="Xamarin.Google.MLKit.Vision.Common" Version="117.2.0" />
+    <PackageReference Update="Xamarin.Google.MLKit.Vision.Common" Version="117.2.1" />
     <PackageReference Update="Xamarin.Google.MLKit.Vision.Interfaces" Version="116.1.0" />
     <PackageReference Update="Xamarin.Google.MLKit.Vision.Internal.Vkp" Version="118.2.2.2" />
     <PackageReference Update="Xamarin.Google.Android.ODML.Image" Version="1.0.0.2-beta1" />


### PR DESCRIPTION
### Does this change any of the generated binding API's?

Could be.

Updated packages:

- `com.google.mlkit:vision-common` - 17.2.0 -> 17.2.1

