### PR TITLE
[Directory.Build.props] Use JavaTypeSystem.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,9 +13,6 @@
     
     <!-- .NET 6+ packages support back to API-21 -->
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
-    
-    <!-- Hold off on JavaTypeSystem until d17-1 for needed bugfixes -->
-    <_AndroidUseJavaLegacyResolver>true</_AndroidUseJavaLegacyResolver>
 
     <!-- Mark .NET6+ packages as supporting trimming -->
     <IsTrimmable>true</IsTrimmable>


### PR DESCRIPTION
The bugs in the new JavaTypeSystem that were preventing us from using it have been fixed.

A side benefit of using it is speed:

|  | Legacy ApiXmlAdjuster | JavaTypeSystem |
| -- | -- | -- |
| Mac Build | 71:56 min | 40:21 min |
| Windows Build | 19:49 min | 13:31 min |

(Our Windows build agents are much more powerful machines than our Mac build agents.)