### PR TITLE
Use internal locked-down Mac VM image for building.

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -40,7 +40,7 @@ jobs:
     parameters:
       timeoutInMinutes: 240
       areaPath: 'DevDiv\Xamarin SDK\Android'
-      macosImage: macOS-12                                    # the name of the macOS VM image (BigSur)
+      macosImage: internal-macos12                            # macOS VM image name, must be "internal" locked down image
       windowsAgentPoolName: android-win-2022
       xcode: $(XcodeVersion)
       dotnet: $(DotNetVersion)                                # the version of .NET Core to use


### PR DESCRIPTION
In order to meet DevDiv "secure supply chain" requirements for CI machines that build software that is shipped, we need to use some special VM images that have been "locked-down" further than the publicly available Azure Pipelines images.

Our Windows `android-win-2022` image already meets this requirement.

This PR updates the Mac image to `internal-macos12` to meet this requirement.

As a side-effect, it looks like this image is twice as fast??!??

Mac Build: `160 min` -> `87 min` 🎉🥳🎈