### PR TITLE
[ci] Fail build if .NET android/maui workloads cannot be installed.

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -11,7 +11,7 @@ variables:
   AndroidBinderatorVersion: 0.5.4
   AndroidXMigrationVersion: 1.0.10
   BootsVersion: 1.1.0.712-preview2
-  DotNetVersion: 6.0.401
+  DotNetVersion: 6.0.402
   XcodeVersion: 13.3.1
   DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
   NuGetOrgSource: https://api.nuget.org/v3/index.json
@@ -52,10 +52,13 @@ jobs:
         - Square
       initSteps:
         - pwsh: |
-            dotnet workload update --verbosity diag --from-rollback-file $(XamarinDotNetWorkloadSource) --source $(Dotnet6Source) --source $(NuGetOrgSource)
-            dotnet workload install android --verbosity diag --skip-manifest-update --source $(Dotnet6Source) --source $(NuGetOrgSource)
-            dotnet workload install maui --verbosity diag --skip-manifest-update --source $(Dotnet6Source) --source $(NuGetOrgSource)
-            dotnet workload update
+            dotnet workload install maui --verbosity diag --from-rollback-file $(XamarinDotNetWorkloadSource) --source $(Dotnet6Source) --source $(NuGetOrgSource)
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "##vso[task.logissue type=error]Failed to install workloads."
+                Write-Host "##vso[task.complete result=Failed;]"
+                exit 0
+            }
+          displayName: Install .NET Workloads
             
         - task: JavaToolInstaller@0
           inputs:

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
     "sdk": 
     {
-        "version": "6.0.401",
-        "rollForward": "latestMinor"
+        "version": "6.0.402",
+        "rollForward": "patch"
     },
     "msbuild-sdks": 
     {


### PR DESCRIPTION
Port the following infrastructure PR's from AndroidX to GPS:
- https://github.com/xamarin/AndroidX/pull/644
- https://github.com/xamarin/AndroidX/pull/645
- https://github.com/xamarin/AndroidX/pull/647