### PR TITLE
[ci] Update TSA area path since old one no longer exists.

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -39,7 +39,7 @@ jobs:
   - template: .ci/build.yml@components
     parameters:
       timeoutInMinutes: 240
-      areaPath: 'DevDiv\Xamarin SDK\Android'
+      areaPath: 'DevDiv\VS Client - Runtime SDKs\Android'
       macosImage: internal-macos12                            # macOS VM image name, must be "internal" locked down image
       windowsAgentPoolName: android-win-2022
       xcode: $(XcodeVersion)


### PR DESCRIPTION
Port https://github.com/xamarin/AndroidX/pull/393 to GPS.

Fixes CI error:
```
TSA was given an invalid Area Path: 'DevDiv\Xamarin SDK\Android'.
```