### PR TITLE
Update to Xamarin.Build.Download 0.11.4.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -621,6 +621,15 @@ Task("samples-directory-build-targets")
 				element_pr.Attributes.Append(attr_version);
 			}
 
+			XmlElement xbd_pr = doc.CreateElement( string.Empty, "PackageReference", string.Empty );
+			element_ig.AppendChild(xbd_pr);
+			XmlAttribute xbd_attr_update = doc.CreateAttribute("Update");
+			xbd_attr_update.Value = "Xamarin.Build.Download";
+			xbd_pr.Attributes.Append(xbd_attr_update);
+			XmlAttribute xbd_attr_version = doc.CreateAttribute("Version");
+			xbd_attr_version.Value = "0.11.4";
+			xbd_pr.Attributes.Append(xbd_attr_version);
+
 			doc.Save( System.IO.Path.Combine("samples", "Directory.Build.targets" ));
 
 			return;

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -299,5 +299,6 @@
     <PackageReference Update="Xamarin.GooglePlayServices.Measurement.Base" Version="121.1.0" />
     <PackageReference Update="Xamarin.GooglePlayServices.Measurement.Api" Version="121.1.0" />
     <PackageReference Update="Xamarin.CheckerFramework.CheckerQual" Version="3.25.0" />
+    <PackageReference Update="Xamarin.Build.Download" Version="0.11.4" />
   </ItemGroup>
 </Project>

--- a/samples/all/FbAll/FbBuildAll.csproj
+++ b/samples/all/FbAll/FbBuildAll.csproj
@@ -58,7 +58,7 @@
     <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.Download" Version="0.11.3" />
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0.5" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />

--- a/samples/all/GpsBuildAll/GpsBuildAll.csproj
+++ b/samples/all/GpsBuildAll/GpsBuildAll.csproj
@@ -57,7 +57,7 @@
     <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.Download" Version="0.11.3" />
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0.5" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />

--- a/samples/all/MLKitBuildAll/MLKitBuildAll.csproj
+++ b/samples/all/MLKitBuildAll/MLKitBuildAll.csproj
@@ -57,7 +57,7 @@
     <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.Download" Version="0.11.3" />
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0.5" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />

--- a/samples/all/PlayBuildAll/PlayBuildAll.csproj
+++ b/samples/all/PlayBuildAll/PlayBuildAll.csproj
@@ -57,7 +57,7 @@
     <Reference Include="Mono.Android" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.Download" Version="0.11.3" />
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0.5" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />

--- a/samples/com.google.android.gms/play-services-ads-lite/AdsLiteSample/AdsLiteSample.csproj
+++ b/samples/com.google.android.gms/play-services-ads-lite/AdsLiteSample/AdsLiteSample.csproj
@@ -119,9 +119,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.10</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.Essentials">
       <Version>1.7.3</Version>
     </PackageReference>

--- a/samples/com.google.android.gms/play-services-ads/AdMobSample/AdMobSample.csproj
+++ b/samples/com.google.android.gms/play-services-ads/AdMobSample/AdMobSample.csproj
@@ -96,9 +96,7 @@
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.4.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.13" />
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.GooglePlayServices.Ads.Lite">
     </PackageReference>
   </ItemGroup>

--- a/samples/com.google.android.gms/play-services-analytics/AnalyticsSample/AnalyticsSample.csproj
+++ b/samples/com.google.android.gms/play-services-analytics/AnalyticsSample/AnalyticsSample.csproj
@@ -98,9 +98,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.7.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.GooglePlayServices.Analytics">
     </PackageReference>
   </ItemGroup>

--- a/samples/com.google.android.gms/play-services-appinvite/AppInviteSample/AppInviteSample.csproj
+++ b/samples/com.google.android.gms/play-services-appinvite/AppInviteSample/AppInviteSample.csproj
@@ -61,9 +61,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.5</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.android.gms/play-services-cast/CastingCall/CastingCall.csproj
+++ b/samples/com.google.android.gms/play-services-cast/CastingCall/CastingCall.csproj
@@ -89,9 +89,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.7" />
     <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.2.2.1" />				

--- a/samples/com.google.android.gms/play-services-drive/DriveSample/DriveSample.csproj
+++ b/samples/com.google.android.gms/play-services-drive/DriveSample/DriveSample.csproj
@@ -61,9 +61,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.5</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.android.gms/play-services-fitness/BasicSensorsApi/BasicSensorsApi.csproj
+++ b/samples/com.google.android.gms/play-services-fitness/BasicSensorsApi/BasicSensorsApi.csproj
@@ -61,9 +61,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.5</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.android.gms/play-services-games/BeGenerous/BeGenerous.csproj
+++ b/samples/com.google.android.gms/play-services-games/BeGenerous/BeGenerous.csproj
@@ -63,9 +63,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.android.gms/play-services-gcm/GCMSample/GCMSample.csproj
+++ b/samples/com.google.android.gms/play-services-gcm/GCMSample/GCMSample.csproj
@@ -60,9 +60,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.7.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.android.gms/play-services-location/LocationSample/LocationSample.csproj
+++ b/samples/com.google.android.gms/play-services-location/LocationSample/LocationSample.csproj
@@ -59,9 +59,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.5</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.GooglePlayServices.Location">
     </PackageReference>
   </ItemGroup>

--- a/samples/com.google.android.gms/play-services-maps/MapsSample/MapsSample.csproj
+++ b/samples/com.google.android.gms/play-services-maps/MapsSample/MapsSample.csproj
@@ -62,9 +62,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.5</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.android.gms/play-services-nearby/NearbySample/NearbySample.csproj
+++ b/samples/com.google.android.gms/play-services-nearby/NearbySample/NearbySample.csproj
@@ -62,9 +62,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.10</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.android.gms/play-services-panorama/PanoramaSample/PanoramaSample.csproj
+++ b/samples/com.google.android.gms/play-services-panorama/PanoramaSample/PanoramaSample.csproj
@@ -61,9 +61,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.7.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Resources\Resource.designer.cs" />

--- a/samples/com.google.android.gms/play-services-places/PlacesAsync/PlacesAsync.csproj
+++ b/samples/com.google.android.gms/play-services-places/PlacesAsync/PlacesAsync.csproj
@@ -62,9 +62,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.7.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.android.gms/play-services-plus/PlusSample/PlusSample.csproj
+++ b/samples/com.google.android.gms/play-services-plus/PlusSample/PlusSample.csproj
@@ -61,9 +61,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.7.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Resources\Resource.designer.cs" />

--- a/samples/com.google.android.gms/play-services-safetynet/SafetyNetSample/SafetyNetSample.csproj
+++ b/samples/com.google.android.gms/play-services-safetynet/SafetyNetSample/SafetyNetSample.csproj
@@ -65,9 +65,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.7.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.android.gms/play-services-vision/VisionSample/VisionSample.csproj
+++ b/samples/com.google.android.gms/play-services-vision/VisionSample/VisionSample.csproj
@@ -61,9 +61,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.7.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.android.gms/play-services-wallet/AndroidPayQuickstart/AndroidPayQuickstart.csproj
+++ b/samples/com.google.android.gms/play-services-wallet/AndroidPayQuickstart/AndroidPayQuickstart.csproj
@@ -65,9 +65,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>    
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.AndroidX.Fragment">
       <Version>1.3.3</Version>
     </PackageReference>

--- a/samples/com.google.android.play/play-services-assetpack/AssetPackSample/AssetPackSample.csproj
+++ b/samples/com.google.android.play/play-services-assetpack/AssetPackSample/AssetPackSample.csproj
@@ -109,9 +109,7 @@
     <PackageReference Include="Xamarin.AndroidX.AppCompat" Version="1.3.1.1" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.0" />
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.GooglePlayServices.Base" />
     <PackageReference Include="Xamarin.Google.Android.Play.Core" /> 
   </ItemGroup>

--- a/samples/com.google.firebase/firebase-ads/FirebaseAdmobQuickstart/FirebaseAdmobQuickstart.csproj
+++ b/samples/com.google.firebase/firebase-ads/FirebaseAdmobQuickstart/FirebaseAdmobQuickstart.csproj
@@ -98,9 +98,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.10</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.Firebase.Ads">
     </PackageReference>
   </ItemGroup>

--- a/samples/com.google.firebase/firebase-analytics/FirebaseAnalyticsQuickstart/FirebaseAnalyticsQuickstart.csproj
+++ b/samples/com.google.firebase/firebase-analytics/FirebaseAnalyticsQuickstart/FirebaseAnalyticsQuickstart.csproj
@@ -62,9 +62,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.firebase/firebase-appindexing/AppIndexingSample/AppIndexingSample.csproj
+++ b/samples/com.google.firebase/firebase-appindexing/AppIndexingSample/AppIndexingSample.csproj
@@ -64,9 +64,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.firebase/firebase-auth/FirebaseAuthQuickstart/FirebaseAuthQuickstart.csproj
+++ b/samples/com.google.firebase/firebase-auth/FirebaseAuthQuickstart/FirebaseAuthQuickstart.csproj
@@ -111,9 +111,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <GoogleServicesJson Include="google-services.json" />

--- a/samples/com.google.firebase/firebase-config/FirebaseConfigQuickstart/FirebaseConfigQuickstart.csproj
+++ b/samples/com.google.firebase/firebase-config/FirebaseConfigQuickstart/FirebaseConfigQuickstart.csproj
@@ -63,9 +63,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/com.google.firebase/firebase-crash/FirebaseCrashReportingQuickstart/FirebaseCrashReportingQuickstart.csproj
+++ b/samples/com.google.firebase/firebase-crash/FirebaseCrashReportingQuickstart/FirebaseCrashReportingQuickstart.csproj
@@ -91,9 +91,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <GoogleServicesJson Include="google-services.json" />

--- a/samples/com.google.firebase/firebase-invites/FirebaseInvitesQuickstart/FirebaseInvitesQuickstart.csproj
+++ b/samples/com.google.firebase/firebase-invites/FirebaseInvitesQuickstart/FirebaseInvitesQuickstart.csproj
@@ -103,9 +103,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
   </ItemGroup>
   <ItemGroup>
     <ProguardConfiguration Include="proguard.cfg" />

--- a/samples/com.google.firebase/firebase-messaging/FirebaseMessagingQuickstart/FirebaseMessagingQuickstart.csproj
+++ b/samples/com.google.firebase/firebase-messaging/FirebaseMessagingQuickstart/FirebaseMessagingQuickstart.csproj
@@ -99,9 +99,7 @@
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.8</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.Firebase.Iid">
       <Version>121.1.0.5</Version>
     </PackageReference>

--- a/samples/com.google.firebase/firebase-storage/FirebaseStorageQuickstart/FirebaseStorageQuickstart.csproj
+++ b/samples/com.google.firebase/firebase-storage/FirebaseStorageQuickstart/FirebaseStorageQuickstart.csproj
@@ -54,9 +54,7 @@
     <Reference Include="Java.Interop" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.Download" >
-      <Version>0.11.3</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.Build.Download" />
     <PackageReference Include="Xamarin.Firebase.Auth" />
     <PackageReference Include="Xamarin.Firebase.Storage" />        
     <PackageReference Include="Xamarin.AndroidX.Migration">

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -304,7 +304,7 @@
   -->
   *@
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.Download" Version="0.11.3" />
+    <PackageReference Include="Xamarin.Build.Download" Version="0.11.4" />
   </ItemGroup>
 
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />

--- a/tests/GooglePlayServices.Tests/GooglePlayServices.Tests.csproj
+++ b/tests/GooglePlayServices.Tests/GooglePlayServices.Tests.csproj
@@ -212,7 +212,7 @@
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="28.0.0.3" />
-    <PackageReference Include="Xamarin.Build.Download" Version="0.11.3" />
+    <PackageReference Include="Xamarin.Build.Download" Version="0.11.4" />
     <PackageReference Include="xunit.core" Version="2.3.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
     <PackageReference Include="xunit.assert" Version="2.3.1" />


### PR DESCRIPTION
Context: https://github.com/xamarin/XamarinComponents/pull/1407

Fixes CI error:
```
/Users/runner/.nuget/packages/xamarin.build.download/0.11.3/buildTransitive/Xamarin.Build.Download.targets(52,3): 
The file '/Users/runner/Library/Caches/XamarinBuildDownload/playservicesbasement-18.1.0/playservicesbasement-18.1.0.aar'
already exists. [/Users/runner/work/1/s/generated/com.google.assistant.appactions.widgets/com.google.assistant.appactions.widgets.csproj]
```

Use the samples `Directory.Build.Targets` to update the version number so we won't have to change every `.csproj` in the future.