### PR TITLE
Use new CI pipeline in AndroidX instead of XamarinComponents.

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -4,25 +4,10 @@ trigger:
 
 pr:
   - main
-  - main_based_androidx*
-  - master_based_androidx*
   
 variables:
-  AndroidBinderatorVersion: 0.5.4
-  AndroidXMigrationVersion: 1.0.10
-  BootsVersion: 1.1.0.712-preview2
-  DotNetVersion: 6.0.402
-  XcodeVersion: 13.3.1
-  DotNet6Source: https://aka.ms/dotnet6/nuget/index.json
-  NuGetOrgSource: https://api.nuget.org/v3/index.json
-  XamarinDotNetWorkloadSource: workloads.json   # or url (check for recent versions - redth)
-                                                # https://aka.ms/dotnet/maui/6.0.400.json
-  # matching builds
-  LegacyXamarinAndroidPkg:  https://aka.ms/xamarin-android-commercial-d17-3-macos
-  LegacyXamarinAndroidVsix: https://aka.ms/xamarin-android-commercial-d17-3-windows
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
-#   XAMARIN_ANDROID_PATH: <path to Xamarin.Android>
 
 resources:
   repositories:
@@ -30,67 +15,21 @@ resources:
       type: github
       name: xamarin/yaml-templates
       endpoint: xamarin
-    - repository: components
+      ref: refs/heads/main
+    - repository: androidx
       type: github
-      name: xamarin/XamarinComponents
+      name: xamarin/androidx
       endpoint: xamarin
+      ref: refs/heads/main
 
 jobs:
-  - template: .ci/build.yml@components
-    parameters:
-      timeoutInMinutes: 240
-      areaPath: 'DevDiv\VS Client - Runtime SDKs\Android'
-      macosImage: internal-macos12                            # macOS VM image name, must be "internal" locked down image
-      windowsAgentPoolName: android-win-2022
-      xcode: $(XcodeVersion)
-      dotnet: $(DotNetVersion)                                # the version of .NET Core to use
-      dotnetStable: $(DotNetVersion)                          # the stable version of .NET Core to use
-      validPackagePrefixes: 
-        # Preferred prefixes
-        - Xamarin
-        - GoogleGson
-        - Square
-      initSteps:
-        - pwsh: |
-            dotnet workload install maui --verbosity diag --from-rollback-file $(XamarinDotNetWorkloadSource) --source $(Dotnet6Source) --source $(NuGetOrgSource)
-            if ($LASTEXITCODE -ne 0) {
-                Write-Host "##vso[task.logissue type=error]Failed to install workloads."
-                Write-Host "##vso[task.complete result=Failed;]"
-                exit 0
-            }
-          displayName: Install .NET Workloads
-            
-        - task: JavaToolInstaller@0
-          inputs:
-            versionSpec: '11'
-            jdkArchitectureOption: 'x64'
-            jdkSourceOption: 'PreInstalled'
-
-      preBuildSteps:
-        - pwsh: |
-            dotnet tool uninstall --global Cake.Tool
-            dotnet tool install --global Cake.Tool --version 2.2.0
-            dotnet tool update --global boots --version $(BootsVersion)
-            boots $(LegacyXamarinAndroidPkg)
-            sudo xcode-select -s "/Applications/Xcode_$(XcodeVersion).app"
-            sudo xcode-select -p
-          condition: eq(variables['System.JobName'], 'macos')
-        - pwsh: |
-            dotnet tool update --global Cake.Tool
-            dotnet tool update --global boots --version $(BootsVersion)
-            boots --url $(LegacyXamarinAndroidVsix) --downgrade-first
-          condition: eq(variables['System.JobName'], 'windows')
-         
-      postBuildSteps:
-        - pwsh: |
-            dotnet cake utilities.cake -t=verify-namespace-file
-      tools:
-        - 'xamarin.androidbinderator.tool': '$(AndroidBinderatorVersion)'
-        - 'xamarin.androidx.migration.tool': '$(AndroidXMigrationVersion)'
+  - template: build/ci/build.yml@androidx
+    parameters: 
+      skipUnitTests: true
+        
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates
       parameters:
-        timeoutInMinutes: 240
         dependsOn: [ 'build' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 

--- a/build.cake
+++ b/build.cake
@@ -638,6 +638,9 @@ Task("samples-directory-build-targets")
 
 Task("samples")
 	.IsDependentOn("libs")
+	.IsDependentOn("samples-only");
+
+Task("samples-only")
 	.IsDependentOn("samples-directory-build-targets")
 	.IsDependentOn("mergetargets")
 	.IsDependentOn("allbindingprojectrefs")
@@ -908,14 +911,22 @@ Task ("clean")
 });
 
 Task ("ci")
+    .IsDependentOn ("ci-build")
+    .IsDependentOn ("ci-samples")
+    ;
+    
+Task ("ci-build")
 	.IsDependentOn ("ci-setup")
 	//.IsDependentOn ("tools-check")
 	//.IsDependentOn ("inject-variables")
 	.IsDependentOn ("binderate")
 	.IsDependentOn ("nuget")
 	//.IsDependentOn ("merge")
-	.IsDependentOn ("samples")
-    .IsDependentOn ("tools-executive-order")
-    ;
+  .IsDependentOn ("tools-executive-order")
+  ;
+
+Task ("ci-samples")
+	.IsDependentOn ("samples-only")
+  ;
 
 RunTarget (TARGET);

--- a/validation.cake
+++ b/validation.cake
@@ -1,0 +1,61 @@
+#addin nuget:?package=Xamarin.Nuget.Validator&version=1.1.1
+
+
+using Xamarin.Nuget.Validator;
+
+
+// SECTION: Arguments and Settings
+
+var ROOT_DIR = (DirectoryPath)Argument ("root", ".");
+var ROOT_OUTPUT_DIR = ROOT_DIR.Combine ("output");
+
+var PACKAGE_NAMESPACES = Argument ("n", Argument ("namespaces", ""))
+	.Split (new [] { ",", ";" }, StringSplitOptions.RemoveEmptyEntries)
+	.ToList ();
+
+
+// SECTION: Main Script
+
+Information ("");
+Information ("Script Arguments:");
+Information ("  Root directory: {0}", MakeAbsolute (ROOT_DIR));
+Information ("  Root output directory: {0}", ROOT_OUTPUT_DIR);
+Information ("  Valid package namespaces: {0}", string.Join (", ", PACKAGE_NAMESPACES));
+Information ("");
+
+
+// SECTION: Validate Output
+
+var options = new NugetValidatorOptions {
+	Copyright = "© Microsoft Corporation. All rights reserved.",
+	Author = "Microsoft",
+	Owner = "", // Was "Microsoft", but this is no longer supported in nuspec: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target
+	NeedsProjectUrl = true,
+	NeedsLicenseUrl = true,
+	ValidateRequireLicenseAcceptance = true,
+	ValidPackageNamespace = PACKAGE_NAMESPACES.ToArray (),
+};
+
+var nupkgFiles = GetFiles (ROOT_OUTPUT_DIR + "/**/*.nupkg");
+
+Information ("Found {0} NuGet packages to validate.", nupkgFiles.Count);
+
+var hasErrors = false;
+
+foreach (var nupkgFile in nupkgFiles) {
+	Information ("Verifying NuGet metadata of {0}...", nupkgFile);
+	var result = NugetValidator.Validate (nupkgFile.FullPath, options);
+	if (result.Success) {
+		Information ("NuGet metadata validation passed.");
+	} else {
+		Error ($"NuGet metadata validation failed for {nupkgFile}:");
+		Error (string.Join (Environment.NewLine + "    ", result.ErrorMessages));
+		hasErrors = true;
+
+		// Update DevOps
+		Warning ($"##vso[task.logissue type=warning]NuGet metadata validation failed for {nupkgFile}.");
+	}
+}
+
+if (hasErrors)
+	throw new Exception ($"Invalid NuGet metadata found.");


### PR DESCRIPTION
Switch to using the streamlined CI pipeline in the AndroidX repository instead of the previous one in XamarinComponents.

AndroidX pipeline: https://github.com/xamarin/AndroidX/pull/658