### PR TITLE
Manual updates 20221216 dependencies cleanup

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -2735,9 +2735,9 @@
         "maven": {
           "artifactId": "dagger",
           "groupId": "com.google.dagger",
-          "version": "2.41",
+          "version": "2.42",
           "nuGetId": "Xamarin.Google.Dagger",
-          "nuGetVersion": "2.41.0.2"
+          "nuGetVersion": "2.42.0"
         }
       },
       "license": "The Apache Software License, Version 2.0"
@@ -2748,9 +2748,9 @@
         "maven": {
           "artifactId": "error_prone_annotations",
           "groupId": "com.google.errorprone",
-          "version": "2.14.0",
+          "version": "2.15.0",
           "nuGetId": "Xamarin.Google.ErrorProne.Annotations",
-          "nuGetVersion": "2.14.0"
+          "nuGetVersion": "2.15.0"
         }
       },
       "license": "The Apache Software License, Version 2.0"
@@ -2761,9 +2761,9 @@
         "maven": {
           "artifactId": "core",
           "groupId": "com.google.zxing",
-          "version": "3.5.0",
+          "version": "3.5.1",
           "nuGetId": "Xamarin.Google.ZXing.Core",
-          "nuGetVersion": "3.5.0.2"
+          "nuGetVersion": "3.5.1"
         }
       },
       "license": "The Apache Software License, Version 2.0"
@@ -2774,9 +2774,9 @@
         "maven": {
           "artifactId": "flatbuffers-java",
           "groupId": "com.google.flatbuffers",
-          "version": "1.12.0",
+          "version": "2.0.8",
           "nuGetId": "Xamarin.Google.FlatBuffers.Java",
-          "nuGetVersion": "1.12.0"
+          "nuGetVersion": "2.0.8"
         }
       }
     },
@@ -2786,9 +2786,9 @@
         "maven": {
           "artifactId": "protobuf-javalite",
           "groupId": "com.google.protobuf",
-          "version": "3.21.9",
+          "version": "3.21.12",
           "nuGetId": "Xamarin.Protobuf.JavaLite",
-          "nuGetVersion": "3.21.9"
+          "nuGetVersion": "3.21.12"
         }
       },
       "license": "BSD 2 Clause AND BSD 3 Clause"

--- a/config.json
+++ b/config.json
@@ -1727,8 +1727,8 @@
       {
         "groupId": "com.google.dagger",
         "artifactId": "dagger",
-        "version": "2.41",
-        "nugetVersion": "2.41.0.2",
+        "version": "2.42",
+        "nugetVersion": "2.42.0",
         "nugetId": "Xamarin.Google.Dagger",
         "dependencyOnly": false,
         "templateSet": "dagger"
@@ -1736,8 +1736,8 @@
       {
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_annotations",
-        "version": "2.14.0",
-        "nugetVersion": "2.14.0",
+        "version": "2.15.0",
+        "nugetVersion": "2.15.0",
         "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "dependencyOnly": false,
         "templateSet": "errorprone"
@@ -1745,8 +1745,8 @@
       {
         "groupId": "com.google.zxing",
         "artifactId": "core",
-        "version": "3.5.0",
-        "nugetVersion": "3.5.0.2",
+        "version": "3.5.1",
+        "nugetVersion": "3.5.1",
         "nugetId": "Xamarin.Google.ZXing.Core",
         "dependencyOnly": false,
         "templateSet": "zxing"
@@ -1754,8 +1754,8 @@
       {
         "groupId": "com.google.flatbuffers",
         "artifactId": "flatbuffers-java",
-        "version": "1.12.0",
-        "nugetVersion": "1.12.0",
+        "version": "2.0.8",
+        "nugetVersion": "2.0.8",
         "nugetId": "Xamarin.Google.FlatBuffers.Java",
         "dependencyOnly": false,
         "templateSet": "flatbuffers"
@@ -1763,8 +1763,8 @@
       {
         "groupId": "com.google.protobuf",
         "artifactId": "protobuf-javalite",
-        "version": "3.21.9",
-        "nugetVersion": "3.21.9",
+        "version": "3.21.12",
+        "nugetVersion": "3.21.12",
         "nugetId": "Xamarin.Protobuf.JavaLite",
         "dependencyOnly": false,
         "excludedRuntimeDependencies": "junit.junit,org.easymock.easymock,org.easymock.easymockclassextension,com.google.truth.truth",

--- a/docs/artifact-list-with-versions.md
+++ b/docs/artifact-list-with-versions.md
@@ -215,11 +215,11 @@
 | 208|com.google.android.datatransport:transport-runtime                    |3.1.7               |Xamarin.Google.Android.DataTransport.TransportRuntime                 |3.1.7               |
 | 209|com.google.android.ump:user-messaging-platform                        |2.0.0               |Xamarin.Google.UserMessagingPlatform                                  |2.0.0.2             |
 | 210|com.google.code.findbugs:jsr305                                       |3.0.2               |Xamarin.Google.Code.FindBugs.JSR305                                   |3.0.2.6             |
-| 211|com.google.dagger:dagger                                              |2.41                |Xamarin.Google.Dagger                                                 |2.41.0.2            |
-| 212|com.google.errorprone:error_prone_annotations                         |2.14.0              |Xamarin.Google.ErrorProne.Annotations                                 |2.14.0              |
-| 213|com.google.zxing:core                                                 |3.5.0               |Xamarin.Google.ZXing.Core                                             |3.5.0.2             |
-| 214|com.google.flatbuffers:flatbuffers-java                               |1.12.0              |Xamarin.Google.FlatBuffers.Java                                       |1.12.0              |
-| 215|com.google.protobuf:protobuf-javalite                                 |3.21.9              |Xamarin.Protobuf.JavaLite                                             |3.21.9              |
+| 211|com.google.dagger:dagger                                              |2.42                |Xamarin.Google.Dagger                                                 |2.42.0              |
+| 212|com.google.errorprone:error_prone_annotations                         |2.15.0              |Xamarin.Google.ErrorProne.Annotations                                 |2.15.0              |
+| 213|com.google.zxing:core                                                 |3.5.1               |Xamarin.Google.ZXing.Core                                             |3.5.1               |
+| 214|com.google.flatbuffers:flatbuffers-java                               |2.0.8               |Xamarin.Google.FlatBuffers.Java                                       |2.0.8               |
+| 215|com.google.protobuf:protobuf-javalite                                 |3.21.12             |Xamarin.Protobuf.JavaLite                                             |3.21.12             |
 | 216|com.google.protobuf:protobuf-lite                                     |3.0.1               |Xamarin.Protobuf.Lite                                                 |3.0.1.6             |
 | 217|com.squareup.okhttp:okhttp                                            |2.7.5               |Square.OkHttp                                                         |2.7.5.6             |
 | 218|com.squareup.okhttp3:logging-interceptor                              |4.4.1               |Square.OkHttp3.LoggingInterceptor                                     |4.4.1               |

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -211,11 +211,11 @@
     <PackageReference Update="Xamarin.Google.Android.DataTransport.TransportRuntime" Version="3.1.7" />
     <PackageReference Update="Xamarin.Google.UserMessagingPlatform" Version="2.0.0.2" />
     <PackageReference Update="Xamarin.Google.Code.FindBugs.JSR305" Version="3.0.2.6" />
-    <PackageReference Update="Xamarin.Google.Dagger" Version="2.41.0.2" />
-    <PackageReference Update="Xamarin.Google.ErrorProne.Annotations" Version="2.14.0" />
-    <PackageReference Update="Xamarin.Google.ZXing.Core" Version="3.5.0.2" />
-    <PackageReference Update="Xamarin.Google.FlatBuffers.Java" Version="1.12.0" />
-    <PackageReference Update="Xamarin.Protobuf.JavaLite" Version="3.21.9" />
+    <PackageReference Update="Xamarin.Google.Dagger" Version="2.42.0" />
+    <PackageReference Update="Xamarin.Google.ErrorProne.Annotations" Version="2.15.0" />
+    <PackageReference Update="Xamarin.Google.ZXing.Core" Version="3.5.1" />
+    <PackageReference Update="Xamarin.Google.FlatBuffers.Java" Version="2.0.8" />
+    <PackageReference Update="Xamarin.Protobuf.JavaLite" Version="3.21.12" />
     <PackageReference Update="Xamarin.Protobuf.Lite" Version="3.0.1.6" />
     <PackageReference Update="Square.OkHttp" Version="2.7.5.6" />
     <PackageReference Update="Square.OkHttp3.LoggingInterceptor" Version="4.4.1" />


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):


### Does this change any of the generated binding API's?


### Describe your contribution

- `com.google.dagger:dagger` - 2.41 -> 2.42
- `com.google.errorprone:error_prone_annotations` - 2.14.0 -> 2.15.0
- `com.google.zxing:core` - 3.5.0 -> 3.5.1
- `com.google.flatbuffers:flatbuffers-java` - 1.12.0 -> 2.0.8
- `com.google.protobuf:protobuf-javalite` - 3.21.9 -> 3.21.12
