### PR TITLE
[ci] Increase build and CG timeout values

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -8,6 +8,7 @@ pr:
 variables:
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
+  ComponentDetection.Timeout: 900
 
 resources:
   repositories:
@@ -20,7 +21,7 @@ resources:
       type: github
       name: xamarin/androidx
       endpoint: xamarin
-      ref: refs/heads/main
+      ref: refs/heads/test-codeql-timeout
 
 jobs:
   - template: build/ci/build.yml@androidx

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -8,7 +8,7 @@ pr:
 variables:
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
-  ComponentDetection.Timeout: 900
+  ComponentDetection.Timeout: 1200
 
 resources:
   repositories:
@@ -21,7 +21,7 @@ resources:
       type: github
       name: xamarin/androidx
       endpoint: xamarin
-      ref: refs/heads/test-codeql-timeout
+      ref: refs/heads/main
 
 jobs:
   - template: build/ci/build.yml@androidx

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -9,6 +9,7 @@ variables:
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
   ComponentDetection.Timeout: 900
+  CodeQL.Cadence: 0
 
 resources:
   repositories:
@@ -26,8 +27,8 @@ resources:
 jobs:
   - template: build/ci/build.yml@androidx
     parameters: 
-      skipUnitTests: true
-        
+      timeoutInMinutes: 240
+
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates
       parameters:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -9,7 +9,6 @@ variables:
   BUILD_NUMBER: $(Build.BuildNumber)
   BUILD_COMMIT: $(Build.SourceVersion)
   ComponentDetection.Timeout: 900
-  CodeQL.Cadence: 0
 
 resources:
   repositories:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -25,7 +25,8 @@ resources:
 
 jobs:
   - template: build/ci/build.yml@androidx
-    parameters: 
+    parameters:
+      skipUnitTests: true
       timeoutInMinutes: 240
 
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:


### PR DESCRIPTION
Recent builds have been timing out during Component Governance:

    [ERROR] The execution did not complete in the alotted time (360 seconds) and has been terminated prior to completion
    [ERROR] To override the default timeout, use the pipeline variable ComponentDetection.Timeout with a larger integer value (in seconds).

Additionally, CodeQL increases the build time when it runs successfully.

Timeout values have been increased to account for these issues.