### PR TITLE
github actions updates

### DIFF
--- a/.github/workflows/new-releases-check.yml
+++ b/.github/workflows/new-releases-check.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: main
         
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.x.x
         
@@ -39,7 +39,7 @@ jobs:
 
     - name: Create Pull Request
       id: cpr
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v5
       with:
         commit-message: Weekly stable updates
         branch-suffix: timestamp


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No.

### Describe your contribution

GitHub actions fail to run, because of outdated actions using Node v12. New updated actions use Node v16.

```
[build](https://github.com/xamarin/AndroidX/actions/runs/4635871484/jobs/8203265833#step:6:105)
GitHub Actions is not permitted to create or approve pull requests.
[build](https://github.com/xamarin/AndroidX/actions/runs/4635871484/jobs/8203265833)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-dotnet@v1, peter-evans/create-pull-request@v3. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

