### PR TITLE
[Directory.Build.props] Add $(_DefaultTargetFrameworks).

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,9 @@
     <RepositoryUrl>https://github.com/xamarin/GooglePlayServicesComponents.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 
+    <!-- Default TFM's we build for -->
+    <_DefaultTargetFrameworks>MonoAndroid12.0;net6.0-android</_DefaultTargetFrameworks>
+
     <!-- Opt out of C#8 features to maintain compatibility with legacy -->
     <AndroidBoundInterfacesContainConstants>false</AndroidBoundInterfacesContainConstants>
     <AndroidBoundInterfacesContainTypes>false</AndroidBoundInterfacesContainTypes>
@@ -17,4 +20,17 @@
     <!-- Mark .NET6+ packages as supporting trimming -->
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
+
+  <!-- Folders that various files get placed into -->
+  <ItemGroup>
+    <_TargetFrameworkNugetBuildFolders Include="build\monoandroid12.0" />
+    <_TargetFrameworkNugetBuildFolders Include="build\net6.0-android31.0" />
+    <_TargetFrameworkNugetBuildFolders Include="buildTransitive\monoandroid12.0" />
+    <_TargetFrameworkNugetBuildFolders Include="buildTransitive\net6.0-android31.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <_TargetFrameworkNugetAarFolders Include="aar\monoandroid12.0" />
+    <_TargetFrameworkNugetAarFolders Include="aar\net6.0-android31.0" />
+  </ItemGroup>
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,5 +1,10 @@
 <Project>
 
+  <!-- Default TFM's we build for -->
+  <PropertyGroup>
+    <_DefaultDotNetSampleTargetFrameworks>net6.0-android</_DefaultDotNetSampleTargetFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
   </PropertyGroup>

--- a/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj
+++ b/samples/dotnet/BuildAllDotNet/BuildAllDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultDotNetSampleTargetFrameworks)</TargetFrameworks>
     
     <!-- Some packages specify a minimum of 28 (eg: Xamarin.AndroidX.HeifWriter) -->
     <!--

--- a/samples/dotnet/BuildAllFbDotNet/BuildAllFbDotNet.csproj
+++ b/samples/dotnet/BuildAllFbDotNet/BuildAllFbDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-android</TargetFramework>    
+    <TargetFramework>$(_DefaultDotNetSampleTargetFrameworks)</TargetFramework>    
     
     <!-- Some packages specify a minimum of 29 (eg: StreamProtect) -->
     <SupportedOSPlatformVersion>29</SupportedOSPlatformVersion>

--- a/samples/dotnet/BuildAllGpsDotNet/BuildAllGpsDotNet.csproj
+++ b/samples/dotnet/BuildAllGpsDotNet/BuildAllGpsDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-android</TargetFramework>    
+    <TargetFramework>$(_DefaultDotNetSampleTargetFrameworks)</TargetFramework>    
     
     <!-- Some packages specify a minimum of 29 (eg: StreamProtect) -->
     <SupportedOSPlatformVersion>29</SupportedOSPlatformVersion>

--- a/samples/dotnet/BuildAllMLKitDotNet/BuildAllMLKitDotNet.csproj
+++ b/samples/dotnet/BuildAllMLKitDotNet/BuildAllMLKitDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-android</TargetFramework>    
+    <TargetFramework>$(_DefaultDotNetSampleTargetFrameworks)</TargetFramework>    
     
     <!-- Some packages specify a minimum of 29 (eg: StreamProtect) -->
     <SupportedOSPlatformVersion>29</SupportedOSPlatformVersion>

--- a/samples/dotnet/BuildAllMauiApp/BuildAllMauiApp.csproj
+++ b/samples/dotnet/BuildAllMauiApp/BuildAllMauiApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-android</TargetFrameworks>
+		<TargetFrameworks>$(_DefaultDotNetSampleTargetFrameworks)</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>BuildAllMauiApp</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -46,23 +46,23 @@
 	</ItemGroup>
 
 	<Import 
-		Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+		Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
 		Project="..\..\..\output\Directory.GPS.packages.props" 
 		/>
 	<Import 
-		Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+		Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
 		Project="..\..\..\output\Directory.FB.packages.props" 
 		/>
 	<Import 
-		Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+		Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
 		Project="..\..\..\output\Directory.MLKit.packages.props" 
 		/>
 	<Import 
-		Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+		Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
 		Project="..\..\..\output\Directory.GP.packages.props" 
 		/>
 		<Import 
-		Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+		Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
 		Project="..\..\..\output\Directory.Diverse.packages.props" 
 		/>
 	
@@ -79,7 +79,7 @@
 	[./samples/dotnet/BuildAllMauiApp.sln]
 	-->
 	<ItemGroup
-		Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+		Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
 		>
 		<PackageReference Include="Xamarin.AndroidX.Security.SecurityCrypto" Version="[1.1.0-alpha03]" />
 	</ItemGroup>

--- a/samples/dotnet/BuildAllXamarinForms/BuildAllXamarinForms.XamarinAndroid/BuildAllXamarinForms.XamarinAndroid.csproj
+++ b/samples/dotnet/BuildAllXamarinForms/BuildAllXamarinForms.XamarinAndroid/BuildAllXamarinForms.XamarinAndroid.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-android31</TargetFramework>
+    <TargetFramework>$(_DefaultDotNetSampleTargetFrameworks)</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/dotnet/Directory.Packages.GPS-FB-MLKit.props
+++ b/samples/dotnet/Directory.Packages.GPS-FB-MLKit.props
@@ -1,22 +1,22 @@
 <Project >
   <Import 
-    Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+    Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
     Project="..\..\output\Directory.GPS.packages.props" 
     />
   <Import 
-    Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+    Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
     Project="..\..\output\Directory.FB.packages.props" 
     />
   <Import 
-    Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+    Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
     Project="..\..\output\Directory.MLKit.packages.props" 
     />
   <Import 
-    Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+    Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
     Project="..\..\output\Directory.GP.packages.props" 
     />
     <Import 
-    Condition="$(TargetFramework.StartsWith('net6.0-android')) == true"
+    Condition="$(TargetFramework.StartsWith('$(_DefaultDotNetSampleTargetFrameworks)')) == true"
     Project="..\..\output\Directory.Diverse.packages.props" 
     />
 </Project>

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -4,12 +4,11 @@
 
 @{
   var targetFrameworkMoniker = "MonoAndroid12.0";
-  var dotnetFrameworkMoniker = "net6.0-android31.0";
 }
 
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>@(targetFrameworkMoniker);@(dotnetFrameworkMoniker)</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     @if (!string.IsNullOrEmpty(Model.AssemblyName)) {
     <AssemblyName>@(Model.AssemblyName)</AssemblyName>
@@ -167,19 +166,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\@(targetFrameworkMoniker)" />
-    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="build\@(dotnetFrameworkMoniker)" />
-    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="buildTransitive\@(targetFrameworkMoniker)" />
-    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="buildTransitive\@(dotnetFrameworkMoniker)" />    
+    <None Include="@(Model.NuGetPackageId).targets" Pack="True" PackagePath="@@(_TargetFrameworkNugetBuildFolders)" />
   </ItemGroup>
 
   @if (@Model.NuGetPackageId == "Xamarin.GooglePlayServices.Basement")
   {
     <ItemGroup>
-      <None Include="..\..\source\com.google.android.gms\play-services-basement\buildtasks\bin\$(Configuration)\Xamarin.GooglePlayServices.Tasks.dll" Pack="True" PackagePath="build\@(targetFrameworkMoniker)" />
-      <None Include="..\..\source\com.google.android.gms\play-services-basement\buildtasks\bin\$(Configuration)\Xamarin.GooglePlayServices.Tasks.dll" Pack="True" PackagePath="build\@(dotnetFrameworkMoniker)" />
-      <None Include="..\..\source\com.google.android.gms\play-services-basement\buildtasks\bin\$(Configuration)\Xamarin.GooglePlayServices.Tasks.dll" Pack="True" PackagePath="buildTransitive\@(targetFrameworkMoniker)" />
-      <None Include="..\..\source\com.google.android.gms\play-services-basement\buildtasks\bin\$(Configuration)\Xamarin.GooglePlayServices.Tasks.dll" Pack="True" PackagePath="buildTransitive\@(dotnetFrameworkMoniker)" />      
+      <None Include="..\..\source\com.google.android.gms\play-services-basement\buildtasks\bin\$(Configuration)\Xamarin.GooglePlayServices.Tasks.dll" Pack="True" PackagePath="@@(_TargetFrameworkNugetBuildFolders)" />
     </ItemGroup>
   }
 
@@ -217,8 +210,7 @@
   <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) {
       if (1==2 && art.MavenArtifactPackaging == "aar") {
-    <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).aar" Pack="True" PackagePath="aar\@(targetFrameworkMoniker)" />
-    <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).aar" Pack="True" PackagePath="aar\@(dotnetFrameworkMoniker)" />
+    <None Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId).aar" Pack="True" PackagePath="@@(_TargetFrameworkNugetAarFolders)" />
       }
     }
   </ItemGroup>

--- a/templates/annotations/Project.cshtml
+++ b/templates/annotations/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/chromium-cronet/Project.cshtml
+++ b/templates/chromium-cronet/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/codehaus-mojo/Project.cshtml
+++ b/templates/codehaus-mojo/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/dagger/Project.cshtml
+++ b/templates/dagger/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/datatransport/Project.cshtml
+++ b/templates/datatransport/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/errorprone/Project.cshtml
+++ b/templates/errorprone/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/findbugs/Project.cshtml
+++ b/templates/findbugs/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/flatbuffers/Project.cshtml
+++ b/templates/flatbuffers/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31.0</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/glide/Project.cshtml
+++ b/templates/glide/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:
@@ -72,13 +72,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <GlideBuildFolders Include="build\monoandroid12.0" />
-    <GlideBuildFolders Include="build\net6.0-android31.0" />
-    <GlideBuildFolders Include="buildTransitive\monoandroid12.0" />
-    <GlideBuildFolders Include="buildTransitive\net6.0-android31.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) 
     {
       switch(@Model.NuGetPackageId)
@@ -99,7 +92,7 @@
           default:
             break; 
       }
-      <None Include="..\..\source\@(Model.MavenArtifacts[0].MavenGroupId)\@(Model.MavenArtifacts[0].MavenArtifactId)\$(PackageId).targets" Pack="True" PackagePath="@@(GlideBuildFolders)" />
+      <None Include="..\..\source\@(Model.MavenArtifacts[0].MavenGroupId)\@(Model.MavenArtifacts[0].MavenArtifactId)\$(PackageId).targets" Pack="True" PackagePath="@@(_TargetFrameworkNugetBuildFolders)" />
       <JavaSourcesJar Include="..\..\externals\@(art.MavenGroupId)\@(art.MavenArtifactId)-sources.jar" Link="Jars\%(Filename)%(Extension)" />
     }
   </ItemGroup>

--- a/templates/grpc/Project.cshtml
+++ b/templates/grpc/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/javax-inject/Project.cshtml
+++ b/templates/javax-inject/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/opencensus/Project.cshtml
+++ b/templates/opencensus/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/perfmark/Project.cshtml
+++ b/templates/perfmark/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/protobuf-lite/Project.cshtml
+++ b/templates/protobuf-lite/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/squareup-javapoet/Project.cshtml
+++ b/templates/squareup-javapoet/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31.0</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/squareup-okhttp/Project.cshtml
+++ b/templates/squareup-okhttp/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/squareup-okhttp3/Project.cshtml
+++ b/templates/squareup-okhttp3/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/squareup-okio/Project.cshtml
+++ b/templates/squareup-okio/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/squareup-picasso/Project.cshtml
+++ b/templates/squareup-picasso/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/squareup-retrofit/Project.cshtml
+++ b/templates/squareup-retrofit/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/squareup-retrofit2/Project.cshtml
+++ b/templates/squareup-retrofit2/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <RootNamespace>@Model.NuGetPackageId</RootNamespace>
     <AssemblyName>@Model.NuGetPackageId</AssemblyName>
     <IsBindingProject>true</IsBindingProject>

--- a/templates/tensorflow-lite/Project.cshtml
+++ b/templates/tensorflow-lite/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/user-messaging-platform/Project.cshtml
+++ b/templates/user-messaging-platform/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:

--- a/templates/zxing/Project.cshtml
+++ b/templates/zxing/Project.cshtml
@@ -1,6 +1,6 @@
 <Project Sdk="Xamarin.Legacy.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;net6.0-android31.0</TargetFrameworks>
+    <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <!--
       No warnings for:


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/712

Although we don't currently build and ship GPS for `net7.0` or `net8.0`, it is a good test exercise to run `generator` against GPS  to ensure we aren't creating any regressions in `generator`.

To do this, we currently have to change the `TargetFrameworks` in many places.

Instead, let's put the default `TargetFrameworks` to build in `Directory.Build.props`, so it only has to be changed in one place.