### PR TITLE
Skip  Executive order on macosx becauseof cake issue

### DIFF
--- a/utilities.cake
+++ b/utilities.cake
@@ -1383,7 +1383,7 @@ static List<string> FindNamespaces (string assembly)
 }
 
 Task("tools-executive-order")
-    .WithCriteria( !IsRunningOnMacOs() )
+    .WithCriteria(IsRunningOnWindows())
     .IsDependentOn ("tools-executive-oreder-csv-and-markdown")
     ;
 

--- a/utilities.cake
+++ b/utilities.cake
@@ -1110,7 +1110,7 @@ Task ("read-analysis-files")
     .IsDependentOn ("api-diff-analysis")
     .IsDependentOn ("list-artifacts")
     .IsDependentOn ("generate-markdown-publish-log")
-    .IsDependentOn ("tools-executive-order")
+    //.IsDependentOn ("tools-executive-order")
     .IsDependentOn ("generate-component-governance")
     .IsDependentOn ("generate-namespace-file")
     .Does
@@ -1383,7 +1383,7 @@ static List<string> FindNamespaces (string assembly)
 }
 
 Task("tools-executive-order")
-    .WithCriteria(IsRunningOnWindows())
+    // .WithCriteria(IsRunningOnWindows()) // did not help as workaround for Error: Bad IL format.
     .IsDependentOn ("tools-executive-oreder-csv-and-markdown")
     ;
 

--- a/utilities.cake
+++ b/utilities.cake
@@ -3,13 +3,13 @@
     dotnet cake spell-check.cake -t=spell-check
  */
 #addin nuget:?package=WeCantSpell.Hunspell&version=4.0.0
-#addin nuget:?package=Newtonsoft.Json&version=13.0.2
-#addin nuget:?package=Cake.FileHelpers&version=5.0.0
-#addin nuget:?package=Mono.Cecil&version=0.11.4
+#addin nuget:?package=Newtonsoft.Json&version=13.0.3
+#addin nuget:?package=Cake.FileHelpers&version=6.1.3
+#addin nuget:?package=Mono.Cecil&version=0.11.5
 
-#addin nuget:?package=HolisticWare.Xamarin.Tools.ComponentGovernance&version=0.0.1.2
-#addin nuget:?package=HolisticWare.Core.Net.HTTP&version=0.0.1
-#addin nuget:?package=HolisticWare.Core.IO&version=0.0.1
+#addin nuget:?package=HolisticWare.Xamarin.Tools.ComponentGovernance&version=0.0.1.4
+#addin nuget:?package=HolisticWare.Core.Net.HTTP&version=0.0.4
+#addin nuget:?package=HolisticWare.Core.IO&version=0.0.4
 
 using System.Collections.Generic;
 
@@ -1383,6 +1383,7 @@ static List<string> FindNamespaces (string assembly)
 }
 
 Task("tools-executive-order")
+    .WithCriteria( !IsRunningOnMacOs() )
     .IsDependentOn ("tools-executive-oreder-csv-and-markdown")
     ;
 


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No. Utilities fixes - executive order genration on mac issue.

https://github.com/cake-build/cake/issues/3996

https://github.com/augustoproiete-repros/repro-cake-build-issue-3996-bad-il-format

### Describe your contribution

Skip building EO data on MacOSX