### PR TITLE
[msbuild] only include `@(ProguardConfiguration)` in apps

### DIFF
--- a/source/GooglePlayServicesTargets.cshtml
+++ b/source/GooglePlayServicesTargets.cshtml
@@ -24,7 +24,7 @@
   <ItemGroup>
     @foreach (var art in @Model.MavenArtifacts) {
       if (art.ProguardFile != null) {
-    <ProguardConfiguration Include="$(MSBuildThisFileDirectory)..\..\proguard\proguard.txt" />
+    <ProguardConfiguration Condition=" '$(AndroidApplication)' == 'true' " Include="$(MSBuildThisFileDirectory)..\..\proguard\proguard.txt" />
       }
     }
   </ItemGroup>


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/729
Context: https://github.com/xamarin/xamarin-android/pull/8025

A customer reported a build error such as:

    C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\33.0.46\targets\Microsoft.Android.Sdk.AndroidLibraries.targets(77,5):
    error XACAAR7014: System.OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.
    at System.Text.StringBuilder.ToString()
    at Xamarin.Android.Tasks.CreateAar.RunTask()
    at Microsoft.Android.Build.Tasks.AndroidTask.Execute()

Somewhere here:

https://github.com/xamarin/xamarin-android/blob/c31f3eda63a16e412a39fa61eb0f885be3c5f543/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs#L108-L114

We have a compounding issue:

* Google Play Services NuGets add `proguard.txt` files to class libraries

* These make it to `YourClassLibrary.aar`

* You might have class libraries that reference other class libraries

* You end up with N^2 `proguard.txt` files and hit OOM.

Step 1 to fix this is to simply not add `@(ProguardConfiguration)` from the Google Play Services NuGets for class libraries.

We can solve the `obj\Debug\lp\173\jl\proguard.txt` entries in xamarin/xamarin-android#8025.