### PR TITLE
Enable DIM for GPS packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,10 +6,12 @@
     <!-- Default TFM's we build for -->
     <_DefaultTargetFrameworks>MonoAndroid12.0;net6.0-android</_DefaultTargetFrameworks>
 
+    <!-- Enable DIM/SIM for Classic (defaults to true on .NET) -->
+    <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
+
     <!-- Opt out of C#8 features to maintain compatibility with legacy -->
     <AndroidBoundInterfacesContainConstants>false</AndroidBoundInterfacesContainConstants>
     <AndroidBoundInterfacesContainTypes>false</AndroidBoundInterfacesContainTypes>
-    <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>false</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
     
     <!-- .NET 6+ generates Resource.designer.cs files for bindings projects which we do not want -->
     <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -79,6 +79,18 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <!-- Include symbol files (*.pdb) in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+
+    @switch (@Model.NuGetPackageId)
+    {
+      case "Xamarin.Google.MLKit.ObjectDetection":
+      case "Xamarin.Google.MLKit.ObjectDetection.Custom":
+      case "Xamarin.Google.MLKit.PoseDetection":
+      case "Xamarin.Google.MLKit.PoseDetection.Accurate":
+    <!-- Filed as https://github.com/xamarin/java.interop/issues/1116 -->
+    <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>false</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
+      break;
+    }
+
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Some GPS interfaces provide useful API as `default` interface methods.  Support for default interface methods has been added to C# and our Android binding tools.

Enable `$(AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods)` so that this support is turned on.

Note there are a few packages that have build errors with this enabled.  Those packages will continue to have this setting turned off.  The issue has been filed here: https://github.com/xamarin/java.interop/issues/1116.