### PR TITLE
Make cake addin dependencies match AndroidX.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1056,6 +1056,7 @@ Task("tools-executive-order")
     (
         () =>
         {
+        Console.WriteLine ("1");
             CakeExecuteScript
                         (
                             "./utilities.cake",

--- a/build.cake
+++ b/build.cake
@@ -1056,7 +1056,9 @@ Task("tools-executive-order")
     (
         () =>
         {
-        Console.WriteLine ("1");
+          // Temporarily disable on Mac until a newer Cake is available
+          // https://github.com/cake-build/cake/issues/3996#issuecomment-1540282182
+          if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             CakeExecuteScript
                         (
                             "./utilities.cake",

--- a/utilities.cake
+++ b/utilities.cake
@@ -1397,7 +1397,8 @@ Task("tools-executive-oreder-csv-and-markdown")
     (
         () =>
         {
-            StringBuilder sb = new StringBuilder();
+         Console.WriteLine ("2");
+           StringBuilder sb = new StringBuilder();
             StringBuilder sb_md = new StringBuilder();
             sb.AppendLine("BuildToolName,BuildToolVersion");
             sb_md.AppendLine("# Executive Order Build Tools Inventory");
@@ -1410,6 +1411,7 @@ Task("tools-executive-oreder-csv-and-markdown")
 			IEnumerable<string> redirectedStandardOutput = null;
 			int exitCodeWithoutArguments;
 			ProcessSettings process_settings = null;
+        Console.WriteLine ("3");
 
             /*
                 dotnet --info
@@ -1436,6 +1438,7 @@ Task("tools-executive-oreder-csv-and-markdown")
                 sb.AppendLine($"dotnet sdk, {version}");
                 sb_md.AppendLine($"{jp.Name}{version}");
             }
+        Console.WriteLine ("4");
 
             List
                 <(
@@ -1454,6 +1457,7 @@ Task("tools-executive-oreder-csv-and-markdown")
                 msbuild_sdks.Add((name, value));
                 sb.AppendLine($"msbuild-sdks {name}, {value}");
             }
+        Console.WriteLine ("5");
 
             /*
             mono --version
@@ -1489,6 +1493,7 @@ Task("tools-executive-oreder-csv-and-markdown")
                 sb.AppendLine($"Mono JIT compiler, Not installed");
             }
 
+        Console.WriteLine ("6");
 
             /*
             nuget
@@ -1516,6 +1521,7 @@ Task("tools-executive-oreder-csv-and-markdown")
                     sb.AppendLine($"nuget, {version}");
                 }
             }
+        Console.WriteLine ("7");
 
             /*
             xamarin-android-binderator --help
@@ -1555,6 +1561,7 @@ Task("tools-executive-oreder-csv-and-markdown")
                     sb.AppendLine($"{parts[0]},{parts[1]}");
                 }
             }
+        Console.WriteLine ("8");
 
             /*
             gradle --version
@@ -1603,6 +1610,7 @@ Task("tools-executive-oreder-csv-and-markdown")
                     sb.AppendLine($"JVM, {version}");
                 }
             }
+        Console.WriteLine ("9");
             /*
             java --version
             */

--- a/utilities.cake
+++ b/utilities.cake
@@ -1,10 +1,12 @@
+// debugging prerequisity
+#tool nuget:?package=Cake.CoreCLR
 /*
     dotnet cake spell-check.cake
     dotnet cake spell-check.cake -t=spell-check
  */
-#addin nuget:?package=WeCantSpell.Hunspell&version=4.0.0
-#addin nuget:?package=Newtonsoft.Json&version=13.0.2
-#addin nuget:?package=Cake.FileHelpers&version=5.0.0
+#addin nuget:?package=WeCantSpell.Hunspell&version=3.0.1
+#addin nuget:?package=Newtonsoft.Json&version=12.0.3
+#addin nuget:?package=Cake.FileHelpers&version=3.2.1
 #addin nuget:?package=Mono.Cecil&version=0.11.4
 
 #addin nuget:?package=HolisticWare.Xamarin.Tools.ComponentGovernance&version=0.0.1.2

--- a/utilities.cake
+++ b/utilities.cake
@@ -2,9 +2,9 @@
     dotnet cake spell-check.cake
     dotnet cake spell-check.cake -t=spell-check
  */
-#addin nuget:?package=WeCantSpell.Hunspell&version=4.0.0
-#addin nuget:?package=Newtonsoft.Json&version=13.0.2
-#addin nuget:?package=Cake.FileHelpers&version=5.0.0
+#addin nuget:?package=WeCantSpell.Hunspell&version=3.0.1
+#addin nuget:?package=Newtonsoft.Json&version=12.0.3
+#addin nuget:?package=Cake.FileHelpers&version=3.2.1
 #addin nuget:?package=Mono.Cecil&version=0.11.4
 
 #addin nuget:?package=HolisticWare.Xamarin.Tools.ComponentGovernance&version=0.0.1.2

--- a/utilities.cake
+++ b/utilities.cake
@@ -1397,7 +1397,7 @@ Task("tools-executive-oreder-csv-and-markdown")
     (
         () =>
         {
-           StringBuilder sb = new StringBuilder();
+            StringBuilder sb = new StringBuilder();
             StringBuilder sb_md = new StringBuilder();
             sb.AppendLine("BuildToolName,BuildToolVersion");
             sb_md.AppendLine("# Executive Order Build Tools Inventory");

--- a/utilities.cake
+++ b/utilities.cake
@@ -2,9 +2,9 @@
     dotnet cake spell-check.cake
     dotnet cake spell-check.cake -t=spell-check
  */
-#addin nuget:?package=WeCantSpell.Hunspell&version=3.0.1
-#addin nuget:?package=Newtonsoft.Json&version=12.0.3
-#addin nuget:?package=Cake.FileHelpers&version=3.2.1
+#addin nuget:?package=WeCantSpell.Hunspell&version=4.0.0
+#addin nuget:?package=Newtonsoft.Json&version=13.0.2
+#addin nuget:?package=Cake.FileHelpers&version=5.0.0
 #addin nuget:?package=Mono.Cecil&version=0.11.4
 
 #addin nuget:?package=HolisticWare.Xamarin.Tools.ComponentGovernance&version=0.0.1.2
@@ -1397,7 +1397,6 @@ Task("tools-executive-oreder-csv-and-markdown")
     (
         () =>
         {
-         Console.WriteLine ("2");
            StringBuilder sb = new StringBuilder();
             StringBuilder sb_md = new StringBuilder();
             sb.AppendLine("BuildToolName,BuildToolVersion");
@@ -1411,7 +1410,6 @@ Task("tools-executive-oreder-csv-and-markdown")
 			IEnumerable<string> redirectedStandardOutput = null;
 			int exitCodeWithoutArguments;
 			ProcessSettings process_settings = null;
-        Console.WriteLine ("3");
 
             /*
                 dotnet --info
@@ -1438,7 +1436,6 @@ Task("tools-executive-oreder-csv-and-markdown")
                 sb.AppendLine($"dotnet sdk, {version}");
                 sb_md.AppendLine($"{jp.Name}{version}");
             }
-        Console.WriteLine ("4");
 
             List
                 <(
@@ -1457,7 +1454,6 @@ Task("tools-executive-oreder-csv-and-markdown")
                 msbuild_sdks.Add((name, value));
                 sb.AppendLine($"msbuild-sdks {name}, {value}");
             }
-        Console.WriteLine ("5");
 
             /*
             mono --version
@@ -1493,7 +1489,6 @@ Task("tools-executive-oreder-csv-and-markdown")
                 sb.AppendLine($"Mono JIT compiler, Not installed");
             }
 
-        Console.WriteLine ("6");
 
             /*
             nuget
@@ -1521,7 +1516,6 @@ Task("tools-executive-oreder-csv-and-markdown")
                     sb.AppendLine($"nuget, {version}");
                 }
             }
-        Console.WriteLine ("7");
 
             /*
             xamarin-android-binderator --help
@@ -1561,7 +1555,6 @@ Task("tools-executive-oreder-csv-and-markdown")
                     sb.AppendLine($"{parts[0]},{parts[1]}");
                 }
             }
-        Console.WriteLine ("8");
 
             /*
             gradle --version
@@ -1610,7 +1603,6 @@ Task("tools-executive-oreder-csv-and-markdown")
                     sb.AppendLine($"JVM, {version}");
                 }
             }
-        Console.WriteLine ("9");
             /*
             java --version
             */


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):


### Does this change any of the generated binding API's?


### Describe your contribution
