### PR TITLE
FIX for CG errors - pom.xml renamed to dependencies.pom

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,7 +17,7 @@
       },
       {
         "templateFile": "source/GooglePlayServicesPom.cshtml",
-        "outputFileRule": "generated/{groupid}.{artifactid}/pom.xml"
+        "outputFileRule": "generated/{groupid}.{artifactid}/dependencies.pom"
       },
       {
         "templateFile": "source/GooglePlayServicesSolutionFilter.cshtml",


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No.

### Describe your contribution

Attempt to fix CG errors like it was solved in AX repo.

Context:

There are 2 jobs related to CG
"Run component detection"
and 
"Component Detection (auto-injected by policy)"

Link to untagged (not for publishing) builds (2nd CG job was not run):

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8575806&view=logs&j=3b059b26-55fe-5273-567a-5b3fa6c051e7&t=c1153fc3-0ba8-5af1-b921-60affc994bb3

Tagged builds skip CG step #1, but run #2

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8575864&view=logs&j=3b059b26-55fe-5273-567a-5b3fa6c051e7&t=c1153fc3-0ba8-5af1-b921-60affc994bb3

Now POM errors in tagged builds (for publishing)

New error fails when CI runs CG step and analyzes pom.xml file in ./generated/*/pom.xml
We have been generating pom.xml for eons with 

1. `AndroidXPom.cshtml`
     https://github.com/xamarin/AndroidX/blob/main/source/AndroidXPom.cshtml
    and
2. `GooglePlayServicesPom.cshtml``
     https://github.com/xamarin/GooglePlayServicesComponents/blob/main/source/GooglePlayServicesPom.cshtml

Only in AX it is called `dependencies.pom` 

https://github.com/xamarin/AndroidX/blob/main/config.json#L23

and in GPS-FB-MLKit `pom.xml`

https://github.com/xamarin/GooglePlayServicesComponents/blob/main/config.json#L20

This PR that uses `dependencies.pom` (renames generated file `pom.xm`) in GPS-FB-MLKit, so we can unblock updates.
