### PR TITLE
Use an updated `generator` for `@RestrictTo` support.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,10 @@
     <!-- Default TFM's we build for -->
     <_DefaultTargetFrameworks>MonoAndroid12.0;net6.0-android;net7.0-android</_DefaultTargetFrameworks>
     
+    <!-- Use an updated 'generator' -->
+    <!-- It's ok to use "Windows" here because we only use managed code from this package -->
+    <_BindingsToolsLocation>$(MSBuildThisFileDirectory)/tools/Microsoft.Android.Sdk.Windows.34.0.43/tools/</_BindingsToolsLocation>
+        
     <!-- Enable DIM/SIM for Classic (defaults to true on .NET) -->
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
 
@@ -21,6 +25,12 @@
 
     <!-- Mark .NET6+ packages as supporting trimming -->
     <IsTrimmable>true</IsTrimmable>
+    
+    <!-- Suppress warnings about `net6.0-android` being EOL -->
+    <CheckEolWorkloads>false</CheckEolWorkloads>
+
+    <!-- Exclude TF-specific transform files by default -->
+    <DefaultTransformExcludes>**/*.MonoAndroid*.0.xml;**/*.net*.0-android.xml</DefaultTransformExcludes>
   </PropertyGroup>
 
   <!-- Folders that various files get placed into -->

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,7 @@
 // Tools needed by cake addins
 // #tool nuget:?package=Cake.CoreCLR               // needed for debugging
 #tool nuget:?package=vswhere&version=3.1.1
+#tool nuget:?package=Microsoft.Android.Sdk.Windows&version=34.0.43
 
 // Cake Addins
 #addin "Cake.FileHelpers"

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -215,7 +215,10 @@
     <TransformFile Include="..\..\source\Metadata.Common.xml" >
       <Link>Transforms/Metadata.Common.xml</Link>
     </TransformFile>
-    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.xml">
+    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.xml" Exclude="$(DefaultTransformExcludes)">
+        <Link>Transforms/%(RecursiveDir)/%(Filename)%(Extension)</Link>
+    </TransformFile>
+    <TransformFile Include="..\..\source\@(Model.MavenGroupId)\@(Model.Name)\Transforms\*.$(TargetFramework).xml">
         <Link>Transforms/%(RecursiveDir)/%(Filename)%(Extension)</Link>
     </TransformFile>
   </ItemGroup>

--- a/source/com.google.mlkit/object-detection-custom/Transforms/Metadata.net7.0-android.xml
+++ b/source/com.google.mlkit/object-detection-custom/Transforms/Metadata.net7.0-android.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+	<!-- Fix public class inheriting from protected class causing duplicate methods -->
+	<attr
+		path="/api/package[@name='com.google.mlkit.vision.objects.custom']/class[@name='CustomObjectDetectorOptions.Builder']"
+		name="extends"
+		>
+		java.lang.Object
+	</attr>
+	<attr
+		path="/api/package[@name='com.google.mlkit.vision.objects.custom']/class[@name='CustomObjectDetectorOptions.Builder']"
+		name="extends-generic-aware"
+		>
+		java.lang.Object
+	</attr>
+</metadata>

--- a/source/com.google.mlkit/object-detection/Transforms/Metadata.net7.0-android.xml
+++ b/source/com.google.mlkit/object-detection/Transforms/Metadata.net7.0-android.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<metadata>    
+	<!-- Fix public class inheriting from protected class causing duplicate methods -->
+	<attr
+		path="/api/package[@name='com.google.mlkit.vision.objects.defaults']/class[@name='ObjectDetectorOptions.Builder']"
+		name="extends"
+		>
+		java.lang.Object
+	</attr>
+	<attr
+		path="/api/package[@name='com.google.mlkit.vision.objects.defaults']/class[@name='ObjectDetectorOptions.Builder']"
+		name="extends-generic-aware"
+		>
+		java.lang.Object
+	</attr>
+</metadata>

--- a/source/com.google.mlkit/pose-detection-accurate/Transforms/Metadata.net7.0-android.xml
+++ b/source/com.google.mlkit/pose-detection-accurate/Transforms/Metadata.net7.0-android.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+	<!-- Fix public class inheriting from protected class causing duplicate methods -->
+	<attr
+		path="/api/package[@name='com.google.mlkit.vision.pose.accurate']/class[@name='AccuratePoseDetectorOptions.Builder']"
+		name="extends"
+		>
+		java.lang.Object
+	</attr>
+	<attr
+		path="/api/package[@name='com.google.mlkit.vision.pose.accurate']/class[@name='AccuratePoseDetectorOptions.Builder']"
+		name="extends-generic-aware"
+		>
+		java.lang.Object
+	</attr>
+</metadata>

--- a/source/com.google.mlkit/pose-detection/Transforms/Metadata.net7.0-android.xml
+++ b/source/com.google.mlkit/pose-detection/Transforms/Metadata.net7.0-android.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<metadata>    
+	<!-- Fix public class inheriting from protected class causing duplicate methods -->
+	<attr
+		path="/api/package[@name='com.google.mlkit.vision.pose.defaults']/class[@name='PoseDetectorOptions.Builder']"
+		name="extends"
+		>
+		java.lang.Object
+	</attr>
+	<attr
+		path="/api/package[@name='com.google.mlkit.vision.pose.defaults']/class[@name='PoseDetectorOptions.Builder']"
+		name="extends-generic-aware"
+		>
+		java.lang.Object
+	</attr>
+</metadata>


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/820

Like https://github.com/xamarin/AndroidX/pull/820 for AndroidX, use an updated `generator` that surfaces API Google has marked with `@RestrictTo` with a warning for consumers that the API is not considered public.

Sample from `api-diff`:

    ## Xamarin.Android.Volley.dll
    ### Namespace Volley
    #### Type Changed: Volley.AsyncNetwork

    Obsoleted methods:
    ```diff
     [Obsolete ("While this member is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.")]
     public virtual void SetBlockingExecutor (Java.Util.Concurrent.IExecutorService executor);
     [Obsolete ("While this member is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.")]
     public virtual void SetNonBlockingExecutor (Java.Util.Concurrent.IExecutorService executor);
     [Obsolete ("While this member is 'public', Google considers it internal API and reserves the right to modify or delete it in the future. Use at your own risk.")]
     public virtual void SetNonBlockingScheduledExecutor (Java.Util.Concurrent.IScheduledExecutorService executor);
    ```
