### PR TITLE
Manual updates 20231215 - CI timeouts 300 minutes

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -27,7 +27,7 @@ jobs:
   - template: build/ci/build.yml@androidx
     parameters:
       skipUnitTests: true
-      timeoutInMinutes: 240
+      timeoutInMinutes: 300
 
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates


### PR DESCRIPTION
### Google Play Services Version (eg: 8.4.0):


### Does this change any of the generated binding API's?


### Describe your contribution
