### PR TITLE
[ci] Switch to using the 1ES mandated pipeline template.

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -10,8 +10,26 @@ variables:
   BUILD_COMMIT: $(Build.SourceVersion)
   ComponentDetection.Timeout: 1200
 
+  # Build variables
+  mainBranchName: main                                                                  # Name of Git "main" branch
+  configuration: Release                                                                # Build configuration: 'Debug', 'Release'
+
+  # Windows specific variables
+  windowsAgentPoolName: Maui-1ESPT                                                      # Windows VM pool name
+  windowsImage: 1ESPT-Windows2022                                                       # Windows VM image name
+  windowsClassicInstaller: https://aka.ms/xamarin-android-commercial-d17-4-windows      # Windows Classic XA installer URL
+  
+  # macOS specific variables
+  macosAgentPoolName: Azure Pipelines                                                   # macOS VM pool name
+  macosImage: internal-macos12                                                          # macOS VM image name
+  macosClassicInstaller:  https://aka.ms/xamarin-android-commercial-d17-4-macos         # macOS Classic XA installer URL
+
 resources:
   repositories:
+    - repository: 1esPipelines
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
     - repository: internal-templates
       type: github
       name: xamarin/yaml-templates
@@ -23,22 +41,49 @@ resources:
       endpoint: xamarin
       ref: refs/heads/main
 
-jobs:
-  - template: build/ci/build.yml@androidx
-    parameters:
-      skipUnitTests: true
-      timeoutInMinutes: 300
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:   
+    pool:
+      name: AzurePipelines-EO
+      image: 1ESPT-Windows2022
+      os: windows
+      
+    stages:
+    - stage: Build
 
-  - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-    - template: sign-artifacts/jobs/v2.yml@internal-templates
-      parameters:
-        dependsOn: [ 'build' ]
-        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+      jobs:
+      - template: build/ci/build.yml@androidx
+        parameters:
+          name: windows
+          buildPool:
+            name: $(windowsAgentPoolName)
+            image: $(windowsImage)
+            os: windows
+          classicInstallerUrl: $(windowsClassicInstaller)
+          mainBranchName: $(mainBranchName)
+          configuration: $(configuration)
+          runAPIScan: true
+          skipUnitTests: true
+          timeoutInMinutes: 300
 
-    - template: compliance/sbom/job.v1.yml@internal-templates
-      parameters:
-        dependsOn: signing
-        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
-        artifactNames: [ nuget-signed ]
-        packageName: googleplayservices
-        packageFilter: '*.nupkg'
+      - template: build/ci/build.yml@androidx
+        parameters:
+          name: macos
+          buildPool:
+            name: $(macosAgentPoolName)
+            vmImage: $(macosImage)
+            os: macOS
+          classicInstallerUrl: $(macosClassicInstaller)
+          mainBranchName: $(mainBranchName)
+          configuration: $(configuration)
+          skipUnitTests: true
+          timeoutInMinutes: 300
+
+      - template: sign-artifacts/jobs/v2.yml@internal-templates
+        parameters:
+          dependsOn: [ 'build_windows' ]
+          artifactName: output-windows
+          usePipelineArtifactTasks: true
+          use1ESTemplate: true
+          condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')


### PR DESCRIPTION
As part of Microsoft's continued push for supply chain security, our CI that builds shipping software must extend an "official" template that can be used to ensure various safety checks have run.

Unfortunately, this requires extensive changes to our CI to fit their model.  This PR requires both necessary changes and cleanup done to make our process mesh better with the template.

The only functional difference should be:
- Previously the outputs of both the `Windows` and `MacOS` builds were copied to the same artifact directory (`"nuget"`) which was signed and released.  This meant that the last one written "won" and that's what we shipped.  The new template didn't like multiple agents writing to the same output directory, so now we only write to `output-windows` and `output-macos`, and we always sign and ship the `output-windows` output.

TODO:
- Find a faster Windows build pool to use.