### PR TITLE
Manual updates 20240315 freeze tf ops

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3491,7 +3491,7 @@
           "groupId": "org.tensorflow",
           "version": "2.14.0",
           "nuGetId": "Xamarin.TensorFlow.Lite.Select.TF.Ops",
-          "nuGetVersion": "2.14.0.1"
+          "nuGetVersion": "2.14.0"
         }
       },
       "license": "The Apache Software License, Version 2.0"

--- a/config.json
+++ b/config.json
@@ -2235,9 +2235,10 @@
         "groupId": "org.tensorflow",
         "artifactId": "tensorflow-lite-select-tf-ops",
         "version": "2.14.0",
-        "nugetVersion": "2.14.0.1",
+        "nugetVersion": "2.14.0",
         "nugetId": "Xamarin.TensorFlow.Lite.Select.TF.Ops",
         "dependencyOnly": false,
+        "frozen" : true,
         "templateSet": "tensorflow-lite"
       },
       {

--- a/docs/artifact-list-with-versions.md
+++ b/docs/artifact-list-with-versions.md
@@ -273,7 +273,7 @@
 | 266|org.tensorflow:tensorflow-lite-api                                    |2.14.0              |Xamarin.TensorFlow.Lite.Api                                           |2.14.0.1            |
 | 267|org.tensorflow:tensorflow-lite-gpu                                    |2.14.0              |Xamarin.TensorFlow.Lite.Gpu                                           |2.14.0.1            |
 | 268|org.tensorflow:tensorflow-lite-gpu-api                                |2.14.0              |Xamarin.TensorFlow.Lite.Gpu.Api                                       |2.14.0.1            |
-| 269|org.tensorflow:tensorflow-lite-select-tf-ops                          |2.14.0              |Xamarin.TensorFlow.Lite.Select.TF.Ops                                 |2.14.0.1            |
+| 269|org.tensorflow:tensorflow-lite-select-tf-ops                          |2.14.0              |Xamarin.TensorFlow.Lite.Select.TF.Ops                                 |2.14.0              |
 | 270|org.tensorflow:tensorflow-android                                     |1.13.1              |Xamarin.TensorFlow.Android                                            |1.13.1.5            |
 | 271|org.tensorflow:tensorflow-lite-support                                |0.4.4               |Xamarin.TensorFlow.Lite.Support.Library                               |0.4.4.2             |
 | 272|org.tensorflow:tensorflow-lite-support-api                            |0.4.4               |Xamarin.TensorFlow.Lite.Support.Api                                   |0.4.4.2             |

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -268,7 +268,7 @@
     <PackageReference Update="Xamarin.TensorFlow.Lite.Api" Version="2.14.0.1" />
     <PackageReference Update="Xamarin.TensorFlow.Lite.Gpu" Version="2.14.0.1" />
     <PackageReference Update="Xamarin.TensorFlow.Lite.Gpu.Api" Version="2.14.0.1" />
-    <PackageReference Update="Xamarin.TensorFlow.Lite.Select.TF.Ops" Version="2.14.0.1" />
+    <PackageReference Update="Xamarin.TensorFlow.Lite.Select.TF.Ops" Version="2.14.0" />
     <PackageReference Update="Xamarin.TensorFlow.Android" Version="1.13.1.5" />
     <PackageReference Update="Xamarin.TensorFlow.Lite.Support.Library" Version="0.4.4.2" />
     <PackageReference Update="Xamarin.TensorFlow.Lite.Support.Api" Version="0.4.4.2" />


### PR DESCRIPTION
### Does this change any of the generated binding API's?

No. Freezing packages because of size limit no NuGet gallery.

### Describe your contribution

Froze packeges.