### PR TITLE
Update `com.google.errorprone.error_prone_annotations`.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1888,8 +1888,8 @@
       {
         "groupId": "com.google.errorprone",
         "artifactId": "error_prone_annotations",
-        "version": "2.23.0",
-        "nugetVersion": "2.23.0.2",
+        "version": "2.26.1",
+        "nugetVersion": "2.26.1",
         "nugetId": "Xamarin.Google.ErrorProne.Annotations",
         "dependencyOnly": false,
         "templateSet": "errorprone"


### PR DESCRIPTION
We need an updated `error_prone_annotations` in order to update `guava`: https://github.com/xamarin/AndroidX/pull/880.

```
No matching artifact config found for: 
    com.google.errorprone.error_prone_annotations:2.26.1
to satisfy dependency of: 
    com.google.guava.guava:33.1.0-android
```