### PR TITLE
Remove Classic support.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <RepositoryType>git</RepositoryType>
 
     <!-- Default TFM's we build for -->
-    <_DefaultTargetFrameworks>MonoAndroid12.0;net6.0-android;net7.0-android</_DefaultTargetFrameworks>
+    <_DefaultTargetFrameworks>net7.0-android</_DefaultTargetFrameworks>
     
     <!-- Use an updated 'generator' -->
     <!-- It's ok to use "Windows" here because we only use managed code from this package -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,17 +35,11 @@
 
   <!-- Folders that various files get placed into -->
   <ItemGroup>
-    <_TargetFrameworkNugetBuildFolders Include="build\monoandroid12.0" />
-    <_TargetFrameworkNugetBuildFolders Include="build\net6.0-android31.0" />
     <_TargetFrameworkNugetBuildFolders Include="build\net7.0-android33.0" />
-    <_TargetFrameworkNugetBuildFolders Include="buildTransitive\monoandroid12.0" />
-    <_TargetFrameworkNugetBuildFolders Include="buildTransitive\net6.0-android31.0" />
     <_TargetFrameworkNugetBuildFolders Include="buildTransitive\net7.0-android33.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <_TargetFrameworkNugetAarFolders Include="aar\monoandroid12.0" />
-    <_TargetFrameworkNugetAarFolders Include="aar\net6.0-android31.0" />
     <_TargetFrameworkNugetAarFolders Include="aar\net7.0-android33.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
-# Google Play Services / Firebase / ML Kit for Xamarin.Android
+# Google Play Services / Firebase / ML Kit for .NET for Android
 
-Xamarin creates and maintains Xamarin.Android bindings for Google Play Services, Firebase, and ML Kit.
+Microsoft creates and maintains .NET for Android bindings for many of Google's [Google Play Services](https://developers.google.com/android),
+[Firebase](https://firebase.google.com/), and [ML Kit](https://developers.google.com/ml-kit) libraries.
+
+Support for Xamarin.Android ended on [May 1st, 2024](https://dotnet.microsoft.com/en-us/platform/support/policy/xamarin). New versions of these packages will not support Xamarin.Android.
 
 ## What is Google Play Services / Firebase / ML Kit
 
-Google Play Services, Firebase, and ML Kit (GPS/FB/MLKit) are a set of libraries that allow Android apps to take advantage of Google 
-APIs and services.
+[Google Play Services](https://developers.google.com/android), [Firebase](https://firebase.google.com/), and [ML Kit](https://developers.google.com/ml-kit)
+ (GPS/FB/MLKit) are a set of libraries that allow Android apps to take advantage of Google APIs and services.
 
 ## Binding Policies
 
 - This repository binds over 200 GPS/FB/MLKit libraries that are published to [NuGet.org](https://nuget.org). The full package list can be found in [config.json](config.json).
-- AndroidX Java artifacts and some dependencies come from [Google's Maven Respository](https://maven.google.com/web/index.html#).
+- GPS/FB/MLKit Java artifacts and some dependencies come from [Google's Maven Respository](https://maven.google.com/web/index.html#).
 - Additional dependencies come from [Maven/Sonatype Central](https://repo1.maven.org/maven2/).
 - Google's release notes for GPS/FB/MLKit libraries are available [here](https://developers.google.com/android/guides/releases).
 - The major/minor/patch version numbers are the GPS/FB/MLKit library version prefixed with a `1`. For example, the NuGet `Xamarin.GooglePlayServices.Maps 117.0.1` binds version `17.0.1` of the GPS library `com.google.android.gms:play-services-maps`.
@@ -31,8 +34,7 @@ Full list of maven artifact with versions to NuGet mappings with versions:
 
 ## License
 
-The license for this repository is specified in 
-[LICENSE.md](LICENSE.md)
+The license for this repository is specified in [LICENSE.md](LICENSE.md).
 
 Each package published from this repository generally contains third-party code (ie: `.jar`/`.aar`) that is governed by its own license.  Per-package license information is available in [cgmanifest.json](cgmanifest.json).
 
@@ -41,12 +43,12 @@ The `externals` build task downloads some external dependencies from Google whic
 
 ## Building
 
-Instructions for building this repository are specified in [BUILDING.md](BUILDING.md)
+Instructions for building this repository are specified in [BUILDING.md](BUILDING.md).
 
 ## Contribution Guidelines
 
-The Contribution Guidelines for this repository are listed in [CONTRIBUTING.md](.github/CONTRIBUTING.md)
+The Contribution Guidelines for this repository are listed in [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ## .NET Foundation
 
-This project is part of the [.NET Foundation](http://www.dotnetfoundation.org/projects)
+This project is part of the [.NET Foundation](http://www.dotnetfoundation.org/projects).

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -39,7 +39,7 @@ resources:
       type: github
       name: xamarin/androidx
       endpoint: xamarin
-      ref: refs/heads/no-classic
+      ref: refs/heads/main
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -39,7 +39,7 @@ resources:
       type: github
       name: xamarin/androidx
       endpoint: xamarin
-      ref: refs/heads/main
+      ref: refs/heads/no-classic
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines

--- a/published-namespaces.txt
+++ b/published-namespaces.txt
@@ -525,7 +525,6 @@ Square.Retrofit2.Converter.Gson
 Square.Retrofit2.Converter.Scalars
 Square.Retrofit2.Http
 System.Runtime.CompilerServices
-System.Runtime.Versioning
 Volley
 Volley.CroNet
 Volley.Toolbox

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <!-- Default TFM's we build for -->
   <PropertyGroup>
-    <_DefaultDotNetSampleTargetFrameworks>net6.0-android</_DefaultDotNetSampleTargetFrameworks>
+    <_DefaultDotNetSampleTargetFrameworks>net7.0-android</_DefaultDotNetSampleTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/samples/dotnet/BuildAllMauiApp/BuildAllMauiApp.csproj
+++ b/samples/dotnet/BuildAllMauiApp/BuildAllMauiApp.csproj
@@ -83,5 +83,12 @@
 		>
 		<PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto" Version="[1.1.0.1-alpha06]" />
 		<PackageReference Update="Xamarin.AndroidX.Security.SecurityCrypto.Ktx" Version="[1.1.0.1-alpha06]" />
+		
+		<!-- Should match version of the referenced 'Xamarin.AndroidX.Collection' package -->
+		<PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.3.0.2" />
+		<PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.3.0.2" />
+
+		<!-- Should match version of the referenced 'Xamarin.AndroidX.Activity' package -->
+		<PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.8.1.1" />
 	</ItemGroup>
 </Project>

--- a/source/GooglePlayServicesProject.cshtml
+++ b/source/GooglePlayServicesProject.cshtml
@@ -6,7 +6,7 @@
   var targetFrameworkMoniker = "MonoAndroid12.0";
 }
 
-<Project Sdk="Xamarin.Legacy.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(_DefaultTargetFrameworks)</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>


### PR DESCRIPTION
Context: https://github.com/xamarin/AndroidX/pull/875

With support for Classic Xamarin.Android [ended May 1st, 2024](https://dotnet.microsoft.com/en-us/platform/support/policy/xamarin), we can start removing all the hacks needed to support both Classic and .NET for Android.

- No longer build EOL frameworks: `MonoAndroid12.0;net6.0-android;`
- No longer need to install classic XA
- No longer need to have classic XA or XF sample builds
- No longer need to use `Xamarin.Legacy.Sdk`

For this PR, we'll only build `net7.0-android`.  A future PR should enable `net8.0-android`.