### PR TITLE
[build] Remove custom `generator` usage.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,10 +5,6 @@
 
     <!-- Default TFM's we build for -->
     <_DefaultTargetFrameworks>net8.0-android</_DefaultTargetFrameworks>
-    
-    <!-- Use an updated 'generator' -->
-    <!-- It's ok to use "Windows" here because we only use managed code from this package -->
-    <_BindingsToolsLocation>$(MSBuildThisFileDirectory)/tools/Microsoft.Android.Sdk.Windows.34.0.95/tools/</_BindingsToolsLocation>
         
     <!-- Enable DIM/SIM for Classic (defaults to true on .NET) -->
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>

--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,6 @@
 // Tools needed by cake addins
 // #tool nuget:?package=Cake.CoreCLR               // needed for debugging
 #tool nuget:?package=vswhere&version=3.1.7
-#tool nuget:?package=Microsoft.Android.Sdk.Windows&version=34.0.95
 
 // Cake Addins
 #addin nuget:?package=Cake.FileHelpers&version=7.0.0


### PR DESCRIPTION
In https://github.com/xamarin/GooglePlayServicesComponents/pull/822 we started using a .NET 8 `generator` to build our `net7.0-android` packages.  Now that we have migrated to .NET 8 and can stay current with .NET releases this is no longer needed.