### PR TITLE
Manual updates 20240725 fix for issue 754

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1620,7 +1620,7 @@
           "groupId": "com.google.firebase",
           "version": "19.0.3",
           "nuGetId": "Xamarin.Firebase.Crashlytics",
-          "nuGetVersion": "19.0.3"
+          "nuGetVersion": "119.0.3"
         }
       },
       "license": "The Apache Software License, Version 2.0"
@@ -1633,7 +1633,7 @@
           "groupId": "com.google.firebase",
           "version": "19.0.3",
           "nuGetId": "Xamarin.Firebase.Crashlytics.Ktx",
-          "nuGetVersion": "19.0.3"
+          "nuGetVersion": "119.0.3"
         }
       },
       "license": "The Apache Software License, Version 2.0"
@@ -1646,7 +1646,7 @@
           "groupId": "com.google.firebase",
           "version": "19.0.3",
           "nuGetId": "Xamarin.Firebase.Crashlytics.NDK",
-          "nuGetVersion": "19.0.3"
+          "nuGetVersion": "119.0.3"
         }
       },
       "license": "The Apache Software License, Version 2.0"

--- a/docs/artifact-list-with-versions.md
+++ b/docs/artifact-list-with-versions.md
@@ -129,9 +129,9 @@
 | 122|com.google.firebase:firebase-config-interop                           |16.0.1              |Xamarin.Firebase.Config.Interop                                       |116.0.1.2           |
 | 123|com.google.firebase:firebase-core                                     |21.1.1              |Xamarin.Firebase.Core                                                 |121.1.1.9           |
 | 124|com.google.firebase:firebase-crash                                    |16.2.1              |Xamarin.Firebase.Crash                                                |116.2.1.16          |
-| 125|com.google.firebase:firebase-crashlytics                              |19.0.3              |Xamarin.Firebase.Crashlytics                                          |19.0.3              |
-| 126|com.google.firebase:firebase-crashlytics-ktx                          |19.0.3              |Xamarin.Firebase.Crashlytics.Ktx                                      |19.0.3              |
-| 127|com.google.firebase:firebase-crashlytics-ndk                          |19.0.3              |Xamarin.Firebase.Crashlytics.NDK                                      |19.0.3              |
+| 125|com.google.firebase:firebase-crashlytics                              |19.0.3              |Xamarin.Firebase.Crashlytics                                          |119.0.3             |
+| 126|com.google.firebase:firebase-crashlytics-ktx                          |19.0.3              |Xamarin.Firebase.Crashlytics.Ktx                                      |119.0.3             |
+| 127|com.google.firebase:firebase-crashlytics-ndk                          |19.0.3              |Xamarin.Firebase.Crashlytics.NDK                                      |119.0.3             |
 | 128|com.google.firebase:firebase-database                                 |21.0.0              |Xamarin.Firebase.Database                                             |121.0.0             |
 | 129|com.google.firebase:firebase-database-collection                      |18.0.1              |Xamarin.Firebase.Database.Collection                                  |118.0.1.9           |
 | 130|com.google.firebase:firebase-database-connection                      |16.0.2              |Xamarin.Firebase.Database.Connection                                  |116.0.2.16          |

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -124,9 +124,9 @@
     <PackageReference Update="Xamarin.Firebase.Config.Interop" Version="116.0.1.2" />
     <PackageReference Update="Xamarin.Firebase.Core" Version="121.1.1.9" />
     <PackageReference Update="Xamarin.Firebase.Crash" Version="116.2.1.16" />
-    <PackageReference Update="Xamarin.Firebase.Crashlytics" Version="19.0.3" />
-    <PackageReference Update="Xamarin.Firebase.Crashlytics.Ktx" Version="19.0.3" />
-    <PackageReference Update="Xamarin.Firebase.Crashlytics.NDK" Version="19.0.3" />
+    <PackageReference Update="Xamarin.Firebase.Crashlytics" Version="119.0.3" />
+    <PackageReference Update="Xamarin.Firebase.Crashlytics.Ktx" Version="119.0.3" />
+    <PackageReference Update="Xamarin.Firebase.Crashlytics.NDK" Version="119.0.3" />
     <PackageReference Update="Xamarin.Firebase.Database" Version="121.0.0" />
     <PackageReference Update="Xamarin.Firebase.Database.Collection" Version="118.0.1.9" />
     <PackageReference Update="Xamarin.Firebase.Database.Connection" Version="116.0.2.16" />

--- a/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.cs
+++ b/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.cs
@@ -1,0 +1,46 @@
+#nullable restore
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.TensorFlow.Lite.Support.Common 
+{
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor']"
+	// [global::Android.Runtime.Register ("org/tensorflow/lite/support/common/TensorProcessor", DoNotGenerateAcw=true)]
+	public partial class TensorProcessor // : global::Xamarin.TensorFlow.Lite.Support.Common.SequentialProcessor 
+    {
+		// [global::Android.Runtime.Register ("org/tensorflow/lite/support/common/TensorProcessor$Builder", DoNotGenerateAcw=true)]
+		public new partial class Builder // : global::Java.Lang.Object 
+        {
+			static Delegate cb_buildTensorProcessor;
+#pragma warning disable 0169
+			static Delegate GetBuildTensorProcessorHandler ()
+			{
+				if (cb_buildTensorProcessor == null)
+					cb_buildTensorProcessor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_BuildTensorProcessor));
+				return cb_buildTensorProcessor;
+			}
+
+			static IntPtr n_BuildTensorProcessor (IntPtr jnienv, IntPtr native__this)
+			{
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.Builder> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.BuildTensorProcessor ());
+			}
+#pragma warning restore 0169
+
+			// Metadata.xml XPath method reference: path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor.Builder']/method[@name='build' and count(parameter)=0]"
+			[Register ("build", "()Lorg/tensorflow/lite/support/common/TensorProcessor;", "GetBuildTensorProcessorHandler")]
+			public virtual unsafe global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor BuildTensorProcessor ()
+			{
+				const string __id = "build.()Lorg/tensorflow/lite/support/common/TensorProcessor;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+					return global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+        }
+    }
+}

--- a/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.cs
+++ b/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.cs
@@ -7,40 +7,40 @@ using Java.Interop;
 namespace Xamarin.TensorFlow.Lite.Support.Common 
 {
 
-    // Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor']"
-    // [global::Android.Runtime.Register ("org/tensorflow/lite/support/common/TensorProcessor", DoNotGenerateAcw=true)]
-    public partial class TensorProcessor // : global::Xamarin.TensorFlow.Lite.Support.Common.SequentialProcessor 
-    {
-        // [global::Android.Runtime.Register ("org/tensorflow/lite/support/common/TensorProcessor$Builder", DoNotGenerateAcw=true)]
-        public new partial class Builder // : global::Java.Lang.Object 
-        {
-            static Delegate cb_buildTensorProcessor;
+	// Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor']"
+	// [global::Android.Runtime.Register ("org/tensorflow/lite/support/common/TensorProcessor", DoNotGenerateAcw=true)]
+	public partial class TensorProcessor // : global::Xamarin.TensorFlow.Lite.Support.Common.SequentialProcessor 
+	{
+		// [global::Android.Runtime.Register ("org/tensorflow/lite/support/common/TensorProcessor$Builder", DoNotGenerateAcw=true)]
+		public new partial class Builder // : global::Java.Lang.Object 
+		{
+			static Delegate cb_buildTensorProcessor;
 #pragma warning disable 0169
-            static Delegate GetBuildTensorProcessorHandler ()
-            {
-                if (cb_buildTensorProcessor == null)
-                    cb_buildTensorProcessor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_BuildTensorProcessor));
-                return cb_buildTensorProcessor;
-            }
+			static Delegate GetBuildTensorProcessorHandler ()
+			{
+				if (cb_buildTensorProcessor == null)
+					cb_buildTensorProcessor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_BuildTensorProcessor));
+				return cb_buildTensorProcessor;
+			}
 
-            static IntPtr n_BuildTensorProcessor (IntPtr jnienv, IntPtr native__this)
-            {
-                var __this = global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.Builder> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-                return JNIEnv.ToLocalJniHandle (__this.BuildTensorProcessor ());
-            }
+			static IntPtr n_BuildTensorProcessor (IntPtr jnienv, IntPtr native__this)
+			{
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.Builder> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.BuildTensorProcessor ());
+			}
 #pragma warning restore 0169
 
-            // Metadata.xml XPath method reference: path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor.Builder']/method[@name='build' and count(parameter)=0]"
-            [Register ("build", "()Lorg/tensorflow/lite/support/common/TensorProcessor;", "GetBuildTensorProcessorHandler")]
-            public virtual unsafe global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor BuildTensorProcessor ()
-            {
-                const string __id = "build.()Lorg/tensorflow/lite/support/common/TensorProcessor;";
-                try {
-                    var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
-                    return global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
-                } finally {
-                }
-            }
-        }
-    }
+			// Metadata.xml XPath method reference: path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor.Builder']/method[@name='build' and count(parameter)=0]"
+			[Register ("build", "()Lorg/tensorflow/lite/support/common/TensorProcessor;", "GetBuildTensorProcessorHandler")]
+			public virtual unsafe global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor BuildTensorProcessor ()
+			{
+				const string __id = "build.()Lorg/tensorflow/lite/support/common/TensorProcessor;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+					return global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+	}
 }

--- a/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.cs
+++ b/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.cs
@@ -7,40 +7,40 @@ using Java.Interop;
 namespace Xamarin.TensorFlow.Lite.Support.Common 
 {
 
-	// Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor']"
-	// [global::Android.Runtime.Register ("org/tensorflow/lite/support/common/TensorProcessor", DoNotGenerateAcw=true)]
-	public partial class TensorProcessor // : global::Xamarin.TensorFlow.Lite.Support.Common.SequentialProcessor 
+    // Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor']"
+    // [global::Android.Runtime.Register ("org/tensorflow/lite/support/common/TensorProcessor", DoNotGenerateAcw=true)]
+    public partial class TensorProcessor // : global::Xamarin.TensorFlow.Lite.Support.Common.SequentialProcessor 
     {
-		// [global::Android.Runtime.Register ("org/tensorflow/lite/support/common/TensorProcessor$Builder", DoNotGenerateAcw=true)]
-		public new partial class Builder // : global::Java.Lang.Object 
+        // [global::Android.Runtime.Register ("org/tensorflow/lite/support/common/TensorProcessor$Builder", DoNotGenerateAcw=true)]
+        public new partial class Builder // : global::Java.Lang.Object 
         {
-			static Delegate cb_buildTensorProcessor;
+            static Delegate cb_buildTensorProcessor;
 #pragma warning disable 0169
-			static Delegate GetBuildTensorProcessorHandler ()
-			{
-				if (cb_buildTensorProcessor == null)
-					cb_buildTensorProcessor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_BuildTensorProcessor));
-				return cb_buildTensorProcessor;
-			}
+            static Delegate GetBuildTensorProcessorHandler ()
+            {
+                if (cb_buildTensorProcessor == null)
+                    cb_buildTensorProcessor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_BuildTensorProcessor));
+                return cb_buildTensorProcessor;
+            }
 
-			static IntPtr n_BuildTensorProcessor (IntPtr jnienv, IntPtr native__this)
-			{
-				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.Builder> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-				return JNIEnv.ToLocalJniHandle (__this.BuildTensorProcessor ());
-			}
+            static IntPtr n_BuildTensorProcessor (IntPtr jnienv, IntPtr native__this)
+            {
+                var __this = global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.Builder> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+                return JNIEnv.ToLocalJniHandle (__this.BuildTensorProcessor ());
+            }
 #pragma warning restore 0169
 
-			// Metadata.xml XPath method reference: path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor.Builder']/method[@name='build' and count(parameter)=0]"
-			[Register ("build", "()Lorg/tensorflow/lite/support/common/TensorProcessor;", "GetBuildTensorProcessorHandler")]
-			public virtual unsafe global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor BuildTensorProcessor ()
-			{
-				const string __id = "build.()Lorg/tensorflow/lite/support/common/TensorProcessor;";
-				try {
-					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
-					return global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
-				} finally {
-				}
-			}
+            // Metadata.xml XPath method reference: path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor.Builder']/method[@name='build' and count(parameter)=0]"
+            [Register ("build", "()Lorg/tensorflow/lite/support/common/TensorProcessor;", "GetBuildTensorProcessorHandler")]
+            public virtual unsafe global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor BuildTensorProcessor ()
+            {
+                const string __id = "build.()Lorg/tensorflow/lite/support/common/TensorProcessor;";
+                try {
+                    var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+                    return global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+                } finally {
+                }
+            }
         }
     }
 }

--- a/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.cs
+++ b/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.cs
@@ -1,0 +1,46 @@
+#nullable restore
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using Java.Interop;
+
+namespace Xamarin.TensorFlow.Lite.Support.Image 
+{
+
+	// Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor']"
+	// [global::Android.Runtime.Register ("org/tensorflow/lite/support/image/ImageProcessor", DoNotGenerateAcw=true)]
+	public partial class ImageProcessor // : global::Xamarin.TensorFlow.Lite.Support.Common.SequentialProcessor 
+    {
+		// Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']"
+		// [global::Android.Runtime.Register ("org/tensorflow/lite/support/image/ImageProcessor$Builder", DoNotGenerateAcw=true)]
+		public new partial class Builder // : global::Java.Lang.Object 
+        {
+			static Delegate cb_buildImageProcessor;
+#pragma warning disable 0169
+			static Delegate GetBuildImageProcessorHandler ()
+			{
+				if (cb_buildImageProcessor == null)
+					cb_buildImageProcessor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_BuildImageProcessor));
+				return cb_buildImageProcessor;
+			}
+
+			static IntPtr n_BuildImageProcessor (IntPtr jnienv, IntPtr native__this)
+			{
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.Builder> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.BuildImageProcessor ());
+			}
+#pragma warning restore 0169
+
+			// Metadata.xml XPath method reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0]"
+			[Register ("build", "()Lorg/tensorflow/lite/support/image/ImageProcessor;", "GetBuildImageProcessorHandler")]
+			public virtual unsafe global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor BuildImageProcessor ()
+			{
+				const string __id = "build.()Lorg/tensorflow/lite/support/image/ImageProcessor;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+					return global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+        }
+}

--- a/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.cs
+++ b/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.cs
@@ -7,41 +7,41 @@ using Java.Interop;
 namespace Xamarin.TensorFlow.Lite.Support.Image 
 {
 
-    // Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor']"
-    // [global::Android.Runtime.Register ("org/tensorflow/lite/support/image/ImageProcessor", DoNotGenerateAcw=true)]
-    public partial class ImageProcessor // : global::Xamarin.TensorFlow.Lite.Support.Common.SequentialProcessor 
-    {
-        // Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']"
-        // [global::Android.Runtime.Register ("org/tensorflow/lite/support/image/ImageProcessor$Builder", DoNotGenerateAcw=true)]
-        public new partial class Builder // : global::Java.Lang.Object 
-        {
-            static Delegate cb_buildImageProcessor;
+	// Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor']"
+	// [global::Android.Runtime.Register ("org/tensorflow/lite/support/image/ImageProcessor", DoNotGenerateAcw=true)]
+	public partial class ImageProcessor // : global::Xamarin.TensorFlow.Lite.Support.Common.SequentialProcessor 
+	{
+		// Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']"
+		// [global::Android.Runtime.Register ("org/tensorflow/lite/support/image/ImageProcessor$Builder", DoNotGenerateAcw=true)]
+		public new partial class Builder // : global::Java.Lang.Object 
+		{
+			static Delegate cb_buildImageProcessor;
 #pragma warning disable 0169
-            static Delegate GetBuildImageProcessorHandler ()
-            {
-                if (cb_buildImageProcessor == null)
-                    cb_buildImageProcessor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_BuildImageProcessor));
-                return cb_buildImageProcessor;
-            }
+			static Delegate GetBuildImageProcessorHandler ()
+			{
+				if (cb_buildImageProcessor == null)
+					cb_buildImageProcessor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_BuildImageProcessor));
+				return cb_buildImageProcessor;
+			}
 
-            static IntPtr n_BuildImageProcessor (IntPtr jnienv, IntPtr native__this)
-            {
-                var __this = global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.Builder> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-                return JNIEnv.ToLocalJniHandle (__this.BuildImageProcessor ());
-            }
+			static IntPtr n_BuildImageProcessor (IntPtr jnienv, IntPtr native__this)
+			{
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.Builder> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.BuildImageProcessor ());
+			}
 #pragma warning restore 0169
 
-            // Metadata.xml XPath method reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0]"
-            [Register ("build", "()Lorg/tensorflow/lite/support/image/ImageProcessor;", "GetBuildImageProcessorHandler")]
-            public virtual unsafe global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor BuildImageProcessor ()
-            {
-                const string __id = "build.()Lorg/tensorflow/lite/support/image/ImageProcessor;";
-                try {
-                    var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
-                    return global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
-                } finally {
-                }
-            }
-        }
-    }
+			// Metadata.xml XPath method reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0]"
+			[Register ("build", "()Lorg/tensorflow/lite/support/image/ImageProcessor;", "GetBuildImageProcessorHandler")]
+			public virtual unsafe global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor BuildImageProcessor ()
+			{
+				const string __id = "build.()Lorg/tensorflow/lite/support/image/ImageProcessor;";
+				try {
+					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+					return global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+				} finally {
+				}
+			}
+		}
+	}
 }

--- a/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.cs
+++ b/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.cs
@@ -7,41 +7,41 @@ using Java.Interop;
 namespace Xamarin.TensorFlow.Lite.Support.Image 
 {
 
-	// Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor']"
-	// [global::Android.Runtime.Register ("org/tensorflow/lite/support/image/ImageProcessor", DoNotGenerateAcw=true)]
-	public partial class ImageProcessor // : global::Xamarin.TensorFlow.Lite.Support.Common.SequentialProcessor 
+    // Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor']"
+    // [global::Android.Runtime.Register ("org/tensorflow/lite/support/image/ImageProcessor", DoNotGenerateAcw=true)]
+    public partial class ImageProcessor // : global::Xamarin.TensorFlow.Lite.Support.Common.SequentialProcessor 
     {
-		// Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']"
-		// [global::Android.Runtime.Register ("org/tensorflow/lite/support/image/ImageProcessor$Builder", DoNotGenerateAcw=true)]
-		public new partial class Builder // : global::Java.Lang.Object 
+        // Metadata.xml XPath class reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']"
+        // [global::Android.Runtime.Register ("org/tensorflow/lite/support/image/ImageProcessor$Builder", DoNotGenerateAcw=true)]
+        public new partial class Builder // : global::Java.Lang.Object 
         {
-			static Delegate cb_buildImageProcessor;
+            static Delegate cb_buildImageProcessor;
 #pragma warning disable 0169
-			static Delegate GetBuildImageProcessorHandler ()
-			{
-				if (cb_buildImageProcessor == null)
-					cb_buildImageProcessor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_BuildImageProcessor));
-				return cb_buildImageProcessor;
-			}
+            static Delegate GetBuildImageProcessorHandler ()
+            {
+                if (cb_buildImageProcessor == null)
+                    cb_buildImageProcessor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_BuildImageProcessor));
+                return cb_buildImageProcessor;
+            }
 
-			static IntPtr n_BuildImageProcessor (IntPtr jnienv, IntPtr native__this)
-			{
-				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.Builder> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-				return JNIEnv.ToLocalJniHandle (__this.BuildImageProcessor ());
-			}
+            static IntPtr n_BuildImageProcessor (IntPtr jnienv, IntPtr native__this)
+            {
+                var __this = global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.Builder> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+                return JNIEnv.ToLocalJniHandle (__this.BuildImageProcessor ());
+            }
 #pragma warning restore 0169
 
-			// Metadata.xml XPath method reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0]"
-			[Register ("build", "()Lorg/tensorflow/lite/support/image/ImageProcessor;", "GetBuildImageProcessorHandler")]
-			public virtual unsafe global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor BuildImageProcessor ()
-			{
-				const string __id = "build.()Lorg/tensorflow/lite/support/image/ImageProcessor;";
-				try {
-					var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
-					return global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
-				} finally {
-				}
-			}
+            // Metadata.xml XPath method reference: path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0]"
+            [Register ("build", "()Lorg/tensorflow/lite/support/image/ImageProcessor;", "GetBuildImageProcessorHandler")]
+            public virtual unsafe global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor BuildImageProcessor ()
+            {
+                const string __id = "build.()Lorg/tensorflow/lite/support/image/ImageProcessor;";
+                try {
+                    var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
+                    return global::Java.Lang.Object.GetObject<global::Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
+                } finally {
+                }
+            }
         }
-	}
+    }
 }

--- a/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.cs
+++ b/source/org.tensorflow/tensorflow-lite-support-api/Additions/Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.cs
@@ -43,4 +43,5 @@ namespace Xamarin.TensorFlow.Lite.Support.Image
 				}
 			}
         }
+	}
 }

--- a/source/org.tensorflow/tensorflow-lite-support-api/Transforms/Metadata.xml
+++ b/source/org.tensorflow/tensorflow-lite-support-api/Transforms/Metadata.xml
@@ -125,17 +125,19 @@
         BuildTensorProcessor
     </attr>
     <attr
-        path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0  and @return='org.tensorflow.lite.support.common.image.ImageProcessor']"
+        path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0 and @return='org.tensorflow.lite.support.image.ImageProcessor']"
         name="managedName"
         >
         BuildImageProcessor
     </attr>
     -->
+    <!--
+    -->
     <remove-node
         path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor.Builder']/method[@name='build' and count(parameter)=0 and @return='org.tensorflow.lite.support.common.TensorProcessor']"
         />
     <remove-node
-        path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0  and @return='org.tensorflow.lite.support.common.image.ImageProcessor']"
+        path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0 and @return='org.tensorflow.lite.support.image.ImageProcessor']"
         />
 
 </metadata>

--- a/source/org.tensorflow/tensorflow-lite-support-api/Transforms/Metadata.xml
+++ b/source/org.tensorflow/tensorflow-lite-support-api/Transforms/Metadata.xml
@@ -1,12 +1,4 @@
 ﻿<metadata>
-    <remove-node
-        path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0]"
-        />
-
-    <remove-node
-        path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor.Builder']/method[@name='build' and count(parameter)=0]"
-        />
-
     <attr
         path="/api/package[@name='org.tensorflow.lite.support.image']/interface[@name='ImageOperator']/method[@name='apply' and count(parameter)=1 and parameter[1][@type='org.tensorflow.lite.support.image.TensorImage']]"
         name="managedReturn"
@@ -122,5 +114,28 @@
         >
         Java.Lang.Object
     </attr>
+
+    <!-- 
+    cb_build
+
+    <attr
+        path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor.Builder']/method[@name='build' and count(parameter)=0 and @return='org.tensorflow.lite.support.common.TensorProcessor']"
+        name="managedName"
+        >
+        BuildTensorProcessor
+    </attr>
+    <attr
+        path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0  and @return='org.tensorflow.lite.support.common.image.ImageProcessor']"
+        name="managedName"
+        >
+        BuildImageProcessor
+    </attr>
+    -->
+    <remove-node
+        path="/api/package[@name='org.tensorflow.lite.support.common']/class[@name='TensorProcessor.Builder']/method[@name='build' and count(parameter)=0 and @return='org.tensorflow.lite.support.common.TensorProcessor']"
+        />
+    <remove-node
+        path="/api/package[@name='org.tensorflow.lite.support.image']/class[@name='ImageProcessor.Builder']/method[@name='build' and count(parameter)=0  and @return='org.tensorflow.lite.support.common.image.ImageProcessor']"
+        />
 
 </metadata>


### PR DESCRIPTION
### Does this change any of the generated binding API's?

Yes. Methods surfaced and renamed

### Describe your contribution

Fixes for issue #754 

Error:

```
./generated/org.tensorflow.tensorflow-lite-support-api/obj/Debug/net8.0-android/generated/src/Xamarin.TensorFlow.Lite.Support.Common.TensorProcessor.cs(163,20): error CS0102: The type 'TensorProcessor.Builder' already contains a definition for 'cb_build' [./generated/org.tensorflow.tensorflow-lite-support-api/org.tensorflow.tensorflow-lite-support-api.csproj::TargetFramework=net8.0-android]
./generated/org.tensorflow.tensorflow-lite-support-api/obj/Debug/net8.0-android/generated/src/Xamarin.TensorFlow.Lite.Support.Image.ImageProcessor.cs(196,20): error CS0102: The type 'ImageProcessor.Builder' already contains a definition for 'cb_build' [./generated/org.tensorflow.tensorflow-lite-support-api/org.tensorflow.tensorflow-lite-support-api.csproj::TargetFramework=net8.0-android]
``` 
Error is caused by multiple (2) versions of one method (`Build()`) that returns different covariant types. Renaming the method does not work, because variable names for Delegates and other are generated based on java method names, not managed, so the managed method name gets changed, but variables cause conflicts.

So, as workaround, 

1. generated code was copied copied
2. method was removed, 
3. generated code was added to additions
4. variable names were changed (`managedName` suffix)

Maybe variable name generation based on `managedName` could prevent this in the future.


Check: issue java.interop
