### PR TITLE
[app-update] Copy metadata from original "core" package.

### DIFF
--- a/config.json
+++ b/config.json
@@ -725,7 +725,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "app-update",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.9",
+        "nugetVersion": "2.1.0.10",
         "nugetId": "Xamarin.Google.Android.Play.App.Update",
         "dependencyOnly": false
       },
@@ -733,7 +733,7 @@
         "groupId": "com.google.android.play",
         "artifactId": "app-update-ktx",
         "version": "2.1.0",
-        "nugetVersion": "2.1.0.9",
+        "nugetVersion": "2.1.0.10",
         "nugetId": "Xamarin.Google.Android.Play.App.Update.Ktx",
         "dependencyOnly": false
       },

--- a/source/com.google.android.play/app-update/Transforms/Metadata.xml
+++ b/source/com.google.android.play/app-update/Transforms/Metadata.xml
@@ -1,2 +1,25 @@
-﻿<metadata>
+<metadata>
+  <!-- 
+        https://github.com/PatGet/XamarinPlayCoreUpdater/pull/20/
+        
+        Removing StateUpdatedListener implementation from InstallStateUpdatedListener interface 
+        and making proper onStateUpdate method mapping where StateT is InstallState 
+    -->
+  <remove-node
+      path="/api/package[@name='com.google.android.play.core.install']/interface[@name='InstallStateUpdatedListener']/implements[contains(@name,'StateUpdatedListener')]"
+        />
+  <add-node
+      path="/api/package[@name='com.google.android.play.core.install']/interface[@name='InstallStateUpdatedListener']"
+        >
+    <method
+        visibility="public" static="false" abstract="true" return="void" name="onStateUpdate"
+        deprecated="not deprecated" final="false" bridge="false" native="false"
+        synchronized="false" synthetic="false"
+            >
+      <parameter
+          type="com.google.android.play.core.install.InstallState"
+          name="state"
+                />
+    </method>
+  </add-node>
 </metadata>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/GooglePlayServicesComponents/issues/900

In April 2022, [Google deprecated](https://developer.android.com/reference/com/google/android/play/core/release-notes) the `com.google.android.play:core` package and split its functionality into four packages, including `com.google.android.play:app-update`.

We need to copy the fix in https://github.com/xamarin/GooglePlayServicesComponents/pull/709 to the new package in order for `StateUpdatedListener.onStateUpdate (InstallState)` to be implementable.